### PR TITLE
Fixes #31 - Prevent actions updates from overwriting each other.

### DIFF
--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -17,24 +17,6 @@ export class ChatManager {
     // Keyed by Combatant ID to allow multiple combatants to process in parallel
     private static _queueSemaphore = new Map<string, Promise<void>>();
 
-    /**
-     * Helper to ensure flag updates for a specific combatant happen sequentially
-     */
-    private static async _enqueueUpdate(combatantId: string, updateFn: () => Promise<void>) {
-        const existingPromise = this._queueSemaphore.get(combatantId) || Promise.resolve();
-
-        const newPromise = existingPromise.then(async () => {
-            try {
-                await updateFn();
-            } catch (err) {
-                console.error("PF2e Action Automation | Queue Update Error:", err);
-            }
-        });
-
-        this._queueSemaphore.set(combatantId, newPromise);
-        return newPromise;
-    }
-
     public static registerOverrideListeners() {
         document.addEventListener('click', async (event) => {
             const target = event.target as HTMLElement;
@@ -50,12 +32,10 @@ export class ChatManager {
                 const combatant = this.getCombatantFromMsg(message);
                 if (!combatant) return;
 
-                await ChatManager._enqueueUpdate((combatant as any).id, async () => {
-                    const c = combatant as any;
-                    const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
-                    queue.push(originMsgId);
-                    await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
-                });
+                const c = combatant as any;
+                const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
+                queue.push(originMsgId);
+                await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
 
                 // Note: If the dialog opens, the render hook (Step 2) will 
                 // handle moving this ID from the queue to the Dialog instance.
@@ -64,19 +44,17 @@ export class ChatManager {
     }
 
     public static async handleDamageModifierDialogRender(combatant: CombatantPF2e, app: any) {
-        await ChatManager._enqueueUpdate((combatant as any).id, async () => {
-            const c = combatant as any;
-            const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
-            if (queue.length === 0) return;
+        const c = combatant as any;
+        const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
+        if (queue.length === 0) return;
 
-            const originMsgId = queue.pop();
-            if (!originMsgId) return;
+        const originMsgId = queue.pop();
+        if (!originMsgId) return;
 
-            await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
+        await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
 
-            // Attach to the app instance AFTER the flag is safely updated
-            app.options.originatingMessageId = originMsgId;
-        });
+        // Attach to the app instance AFTER the flag is safely updated
+        app.options.originatingMessageId = originMsgId;
     }
 
     public static getCombatantFromMsg(message: any): CombatantPF2e | undefined {
@@ -110,19 +88,16 @@ export class ChatManager {
             delete activeDialog.options.originatingMessageId;
         } else {
             // B. Fallback to Queue (The Shift+Click scenario)
-            // We wrap this in the semaphore too to ensure we don't have a read/write collision
-            await this._enqueueUpdate((combatant as any).id, async () => {
-                const c = combatant as any;
-                const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
+            const c = combatant as any;
+            const queue = (c.getFlag(SCOPE, 'pendingDamageQueue') as string[]) || [];
 
-                originatingMsgId = queue.shift(); // FIFO for rolls
+            originatingMsgId = queue.shift(); // FIFO for rolls
 
-                if (queue.length > 0) {
-                    await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
-                } else {
-                    await c.unsetFlag(SCOPE, 'pendingDamageQueue');
-                }
-            });
+            if (queue.length > 0) {
+                await c.setFlag(SCOPE, 'pendingDamageQueue', queue);
+            } else {
+                await c.unsetFlag(SCOPE, 'pendingDamageQueue');
+            }
         }
 
         if (!originatingMsgId) {
@@ -355,9 +330,9 @@ export class ChatManager {
     /**
      * If we delete a message, delete the associated action (unless it is part of the reroll queue)
      */
-    static handleDeletedMessage(combatant: CombatantPF2e, msgId: string) {
+    static async handleDeletedMessage(combatant: CombatantPF2e, msgId: string) {
         if (this.rerollQueueIncludes(combatant, msgId)) return;
-        ActionManager.removeAction(combatant, msgId);
+        await ActionManager.removeAction(combatant, msgId);
     }
 
     /**

--- a/src/MovementManager.ts
+++ b/src/MovementManager.ts
@@ -9,8 +9,6 @@ const MOVEMENT_FLAG = "movementHistorySnapshot";
 
 export class MovementManager {
 
-    // Ensure we only process one movement (and one movement fully) before the next one
-    private static _processingQueue = new Map<string, Promise<void>>();
     // Synchronous local storage for history length to prevent race conditions
     private static _historyLengths = new Map<string, number>();
     /**
@@ -26,19 +24,14 @@ export class MovementManager {
 
         // Use tokenDoc.id as the primary key for physical movement history
         const tokenId = tokenDoc.id;
-        const existingPromise = MovementManager._processingQueue.get(tokenId) || Promise.resolve();
+        const history = tokenDoc._movementHistory || [];
+        const coordList = history.map((p: any) => ({ x: p.x, y: p.y, elevation: p.elevation ?? 0 }));
+        try {
+            await MovementManager._processMovement(combatant, tokenDoc, coordList, false);
+        } catch (err) {
+            logError("Movement Processing Error:", err);
+        }
 
-        const newPromise = existingPromise.then(async () => {
-            const history = tokenDoc._movementHistory || [];
-            const coordList = history.map((p: any) => ({ x: p.x, y: p.y, elevation: p.elevation ?? 0 }));
-            try {
-                await MovementManager._processMovement(combatant, tokenDoc, coordList, false);
-            } catch (err) {
-                logError("Movement Processing Error:", err);
-            }
-        });
-
-        MovementManager._processingQueue.set(tokenId, newPromise);
     }
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,10 @@ import { MovementManager } from "./MovementManager";
 import { WrapperManager } from "./WrapperManager";
 import { SocketsManager } from "./SocketManager";
 import { ChatMessagePF2e, CombatantPF2e, EncounterPF2e } from "module-helpers"
-import { logConsole } from "./logger";
+import { logConsole, logError, logInfo, logWarn } from "./logger";
 import { SCOPE, recentIntent } from "./globals";
 
+// string is the combatant ID.
 const _queues = new Map<string, Promise<void>>();
 
 // Initialization
@@ -49,11 +50,10 @@ Hooks.on("closeDamageModifierDialog", async (app: any) => {
         tokenId ? c.tokenId === tokenId : c.actorId === actorId
     );
 
-    // 4. Use your semaphore to safely pop the abandoned intent from the queue
     const c = combatant as any;
     if (!c?.id || !combatant) return;
 
-    // Safety cleanup is a write operation, enqueue it
+    // 4. Safety cleanup is a write operation, enqueue it
     enqueueAction(c.id, async () => await ChatManager.handleDamageModifierDialogRender(combatant, app));
 });
 
@@ -92,13 +92,11 @@ Hooks.on("deleteChatMessage", async (message: ChatMessagePF2e) => {
 Hooks.on("deleteCombat", async (combat: EncounterPF2e) => {
     const g = game as unknown as Game;
 
-    // Ensure only the primary GM clears the Quickened snapshot flags
     if (game.user?.id !== game.users?.activeGM?.id) return;
 
     for (const combatant of (combat.combatants as any)) {
         const actor = combatant.actor;
         if (actor) {
-            // Passing 'any' here satisfies the ActorPF2e requirement of the handler
             await ActorHandler.cleanup(actor);
         }
     }
@@ -128,6 +126,8 @@ Hooks.on("preCreateChatMessage", (message: any) => {
 
 // Rendering the chat message
 Hooks.on("renderChatMessage", (message: ChatMessagePF2e, html: any) => {
+    // Does not need enqueuing - This only create messages and click handlers -> which creates more messages.  So no
+    // modifications of actions here
     ChatManager.onRenderChatMessage(message, html);
 });
 
@@ -194,7 +194,6 @@ Hooks.on("updateChatMessage", (message: ChatMessagePF2e, updateData: any) => {
 Hooks.on("updateCombat", async (combat: EncounterPF2e, updateData: any, options: any, userId: string) => {
     const g = game as unknown as Game;
 
-    // Use Active GM check to ensure only one client processes the turn transition
     if (game.user?.id !== game.users?.activeGM?.id) return;
 
     const isTurnChange = "turn" in updateData || "round" in updateData;
@@ -223,16 +222,15 @@ Hooks.on("updateToken", (tokenDoc: any, update: any) => {
     const combatant: Combatant = tokenDoc.combatant;
     if (!combatant.id) return;
 
-    // Enqueue the movement
     enqueueAction(combatant.id, async () => await MovementManager.handleTokenUpdate(tokenDoc, update));
 });
 
 export async function enqueueAction(combatantId: string, actionFn: () => Promise<void>) {
     const existingPromise = _queues.get(combatantId);
 
-    // LOGGING: Check if we are actually waiting
+    // LOGGING: Check if we are actually waiting, useful if debugMode is on I think?
     if (existingPromise) {
-        console.warn(`Action Tracker | RACE PREVENTED: New action for ${combatantId} is waiting for a previous operation to finish.`);
+        logWarn(`Action Tracker | RACE PREVENTED: New action for ${combatantId} is waiting for a previous operation to finish.`);
     }
 
     const startPromise = existingPromise || Promise.resolve();
@@ -243,12 +241,12 @@ export async function enqueueAction(combatantId: string, actionFn: () => Promise
             await actionFn();
             const end = performance.now();
 
-            // LOGGING: Performance check
+            // LOGGING: Performance check - also useful stat to know if people still have trouble with this
             if ((end - start) > 100) {
-                console.log(`Action Tracker | Slow Operation: ${combatantId} took ${Math.round(end - start)}ms`);
+                logInfo(`Action Tracker | Slow Operation: ${combatantId} took ${Math.round(end - start)}ms`);
             }
         } catch (err) {
-            console.error("Action Tracker | Queue Error:", err);
+            logError("Action Tracker | Queue Error:", err);
         }
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import { ChatMessagePF2e, CombatantPF2e, EncounterPF2e } from "module-helpers"
 import { logConsole } from "./logger";
 import { SCOPE, recentIntent } from "./globals";
 
+const _queues = new Map<string, Promise<void>>();
+
 // Initialization
 Hooks.once("init", () => {
     SettingsManager.registerSettings();
@@ -47,35 +49,43 @@ Hooks.on("closeDamageModifierDialog", async (app: any) => {
         tokenId ? c.tokenId === tokenId : c.actorId === actorId
     );
 
-    // GUARD: If no combatant is found (e.g. combat ended or out of combat), stop.
-    if (!combatant) return;
-
     // 4. Use your semaphore to safely pop the abandoned intent from the queue
     const c = combatant as any;
-    await ChatManager.handleDamageModifierDialogRender(combatant, app);
+    if (!c?.id || !combatant) return;
+
+    // Safety cleanup is a write operation, enqueue it
+    enqueueAction(c.id, async () => await ChatManager.handleDamageModifierDialogRender(combatant, app));
 });
 
 // Create Chat Hook
 Hooks.on("createChatMessage", async (message: ChatMessagePF2e) => {
     if (game.user?.id !== game.users?.activeGM?.id) return;
-    await ChatManager.handleChatPayload(message);
+
+    const combatant = ChatManager.getCombatantFromMsg(message);
+    const c = combatant as unknown as Combatant
+    if (!c?.id) return;
+
+    // Enqueue the chat payload
+    enqueueAction(c.id, async () => await ChatManager.handleChatPayload(message));
 });
 
 // Delete Chat hook
-Hooks.on("deleteChatMessage", (message: ChatMessagePF2e) => {
+Hooks.on("deleteChatMessage", async (message: ChatMessagePF2e) => {
     if (!(game as any).combat?.active || !message.id) return;
 
     const speaker = message.speaker;
     const combatant = game.combat?.combatants.find((c: any) =>
         speaker.token ? c.tokenId === speaker.token : c.actorId === speaker.actor
     );
+    const c = combatant as any as Combatant
 
-    if (!combatant) return;
+    if (!combatant || !c.id) return;
 
     const context = message.flags?.pf2e;
     if (context && "isReroll" in context && context.isReroll) return;
 
-    ChatManager.handleDeletedMessage(combatant, message.id);
+    // Enqueue deleting the action
+    enqueueAction(c.id, async () => await ChatManager.handleDeletedMessage(combatant, message.id!));
 });
 
 // End of Combat hook
@@ -104,7 +114,6 @@ Hooks.on("preCreateChatMessage", (message: any) => {
     const speaker = message.speaker;
     const uniqueKey = speaker.token || speaker.actor;
     const intentItemId = recentIntent.get(uniqueKey);
-    const combatant = ChatManager.getCombatantFromMsg(message);
 
     // PF2e uses origin.uuid for item links in chat
     const messageItemId = message.flags?.pf2e?.origin?.uuid?.split('.').pop();
@@ -143,13 +152,26 @@ Hooks.on("renderDamageModifierDialog", async (app: any, html: JQuery) => {
     );
 
     if (!combatant) return;
-    ChatManager.handleDamageModifierDialogRender(combatant, app);
+    const c = combatant as unknown as Combatant
+    if (!c?.id || !combatant) return;
+
+    enqueueAction(c.id, async () => await ChatManager.handleDamageModifierDialogRender(combatant, app));
 });
 
 // Chat card changed (like Heal selecting a cost or visibility)
 Hooks.on("updateChatMessage", (message: ChatMessagePF2e, updateData: any) => {
-    if (updateData.flags?.pf2e) {
-        ChatManager.handleChatPayload(message);
+    const combat = game.combat;
+    if (!combat?.active) return;
+    // Find the combatant associated with this message
+    const speaker = message.speaker;
+    const combatant = combat.combatants.find((c: any) =>
+        speaker.token ? c.tokenId === speaker.token : c.actorId === speaker.actor
+    );
+    const c = combatant as unknown as Combatant
+    if (!c?.id) return;
+
+    if (updateData.flags?.pf2e || updateData.whisper) {
+        enqueueAction(c.id, async () => await ChatManager.handleChatPayload(message));
     }
 
     // Check for any visibility-related changes
@@ -159,15 +181,6 @@ Hooks.on("updateChatMessage", (message: ChatMessagePF2e, updateData: any) => {
         "flags" in updateData; // Catching system-specific visibility flags if any
 
     if (visibilityChanged) {
-        const combat = game.combat;
-        if (!combat?.active) return;
-
-        // Find the combatant associated with this message
-        const speaker = message.speaker;
-        const combatant = combat.combatants.find((c: any) =>
-            speaker.token ? c.tokenId === speaker.token : c.actorId === speaker.actor
-        );
-
         if (combatant) {
             // Trigger a re-render. 
             // renderPip will now see the new message.visible status 
@@ -205,10 +218,40 @@ Hooks.on("updateCombat", async (combat: EncounterPF2e, updateData: any, options:
 // Movement Hook
 Hooks.on("updateToken", (tokenDoc: any, update: any) => {
     if (game.user?.id !== game.users?.activeGM?.id) return;
-
-    // Only care if x or y changed or movement type
     if (!("x" in update || "y" in update || update.movementAction)) return;
 
-    // Delegate everything to MovementManager
-    MovementManager.handleTokenUpdate(tokenDoc, update);
+    const combatant: Combatant = tokenDoc.combatant;
+    if (!combatant.id) return;
+
+    // Enqueue the movement
+    enqueueAction(combatant.id, async () => await MovementManager.handleTokenUpdate(tokenDoc, update));
 });
+
+export async function enqueueAction(combatantId: string, actionFn: () => Promise<void>) {
+    const existingPromise = _queues.get(combatantId);
+
+    // LOGGING: Check if we are actually waiting
+    if (existingPromise) {
+        console.warn(`Action Tracker | RACE PREVENTED: New action for ${combatantId} is waiting for a previous operation to finish.`);
+    }
+
+    const startPromise = existingPromise || Promise.resolve();
+
+    const newPromise = startPromise.then(async () => {
+        try {
+            const start = performance.now();
+            await actionFn();
+            const end = performance.now();
+
+            // LOGGING: Performance check
+            if ((end - start) > 100) {
+                console.log(`Action Tracker | Slow Operation: ${combatantId} took ${Math.round(end - start)}ms`);
+            }
+        } catch (err) {
+            console.error("Action Tracker | Queue Error:", err);
+        }
+    });
+
+    _queues.set(combatantId, newPromise);
+    return newPromise;
+}


### PR DESCRIPTION
## 🚀 Automated Action Tracker - Release PR

### 📋 Pre-Merge Checklist
- [ X ] **Version Bump:** I have updated the version in `package.json` (Current: Leaving as is, waiting for Roi's changes).
- [ X ] **Local Check:** The `dist/main.js` has been built and looks correct.
- [ X ] **Issue Linking:** This PR closes the issue listed below.

### 🔗 Associated Issue
Closes #31 

### 📝 Change Summary
- Removed individual locking schemes for different types and implemented a global queue locking mechanism in main.  Each time something in main could update the ActionLogEntry for a combatant, it should use this new global queue from here on out.  This ensures that there are no race conditions.

Note: Implemented in main instead of near the DB write because movement is a pain to track against and movement actions might change other movement action outcomes (i.e. 30 move speed, move 25 feet -> 5 feet -> 5 feet, if the second overwrites the first, it will still edit the first action because it may not have added the other coordinates)