### PR TITLE
Fix #32 / Fix #34 - Add an Action library to implement gained actions…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "pf2e-auto-action-tracker",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "link": "cmd /c \"if exist \"%LOCALAPPDATA%\\FoundryVTT\\Data\\modules\\pf2e-auto-action-tracker\" rmdir \"%LOCALAPPDATA%\\FoundryVTT\\Data\\modules\\pf2e-auto-action-tracker\" && mklink /j \"%LOCALAPPDATA%\\FoundryVTT\\Data\\modules\\pf2e-auto-action-tracker\" \"C:\\Users\\Chris\\proj\\pf2e-auto-action-tracker\\dist\"\"",
     "preview": "vite preview",
-    "test": "node scripts/smoke-test.mjs && node --experimental-strip-types scripts/hud-tracker-test.mjs",
+    "test": "node --experimental-strip-types scripts/run-tests.mjs",
     "zip": "powershell -Command \"New-Item -ItemType Directory -Force -Path pf2e-auto-action-tracker; Copy-Item -Path dist\\* -Destination pf2e-auto-action-tracker -Recurse -Force; Copy-Item -Path module.json, README.md -Destination pf2e-auto-action-tracker -Force; Compress-Archive -Path pf2e-auto-action-tracker -DestinationPath pf2e-auto-action-tracker.zip -Force; Remove-Item -Recurse -Force pf2e-auto-action-tracker\""
   },
   "devDependencies": {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,23 @@
+import { readdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const files = readdirSync(__dirname).filter(file => file.endsWith("-test.mjs"));
+
+console.log("🚀 Starting Test Suite...");
+
+for (const file of files) {
+    console.log(`\n▶ Running ${file}...`);
+    try {
+        await import(pathToFileURL(join(__dirname, file)).href);
+        console.log(`✅ ${file} passed!`);
+    } catch (e) {
+        console.error(`❌ ${file} failed!`);
+        console.error(e);
+        process.exit(1);
+    }
+}
+
+console.log("\n🎉 All tests passed successfully!");

--- a/scripts/slot-allocation-test.mjs
+++ b/scripts/slot-allocation-test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { ActorHandler } from "../src/ActorHandler.ts";
+
+class MockActor {
+    constructor(slugs = [], conditions = []) {
+        this.items = slugs.map(slug => ({ slug }));
+        this.conditions = conditions;
+        this.system = { resources: { reactions: { max: 1 } } };
+    }
+    hasCondition(slug) {
+        return this.conditions.includes(slug);
+    }
+}
+
+class MockCombatant {
+    constructor(actor, flags = {}) {
+        this.actor = actor;
+        this.flags = flags;
+    }
+    getFlag(scope, key) {
+        return this.flags[key];
+    }
+}
+
+// Ensure the ActorHandler is loaded
+const ah = ActorHandler;
+
+// Test 1: Slot sorting
+const actor1 = new MockActor(['tactical-strike']);
+const combatant1 = new MockCombatant(actor1);
+
+const slots = ah.getSlots(combatant1, 'action');
+// Tactical strike grants 1 extra action. Base actions = 3. Total slots = 4.
+assert.equal(slots.length, 4);
+
+// The restricted slot (tactical strike, allowedSlugs: ['strike']) should be FIRST.
+assert.equal(slots[0].isBase, false);
+assert.equal(slots[0].definition.slug, 'tactical-strike');
+assert.equal(slots[1].isBase, true);
+assert.equal(slots[2].isBase, true);
+assert.equal(slots[3].isBase, true);
+
+// Test 2: Overspend Calculation
+const log1 = [
+    { type: 'action', cost: 1, slug: 'stride' }, // Should consume base slot
+    { type: 'action', cost: 1, slug: 'stride' }, // Should consume base slot
+    { type: 'action', cost: 1, slug: 'strike' }  // Should consume restricted slot (tactical-strike)
+];
+
+const result1 = ah.allocateSlots(combatant1, log1, 'action');
+assert.equal(result1.overspent.length, 0);
+assert.equal(result1.slots[0].spentBy, log1[2]); // Tactical strike used by strike
+assert.equal(result1.slots[1].spentBy, log1[0]); // Base used by stride
+assert.equal(result1.slots[2].spentBy, log1[1]); // Base used by stride
+assert.equal(result1.slots[3].spentBy, undefined);
+
+// Test 3: Complex overlap
+// Add a hypothetical feat to AddReactionsLibrary for this test or just mock it.
+// Wait, we can't easily mock AddReactionsLibrary because it's imported in ActorHandler.
+// So we use quickened.
+const actor2 = new MockActor([], []);
+// Quickened allows: "strike", "stride", "step", "interact", "sustain-a-spell"
+const combatant2 = new MockCombatant(actor2, { isQuickenedSnapshot: true });
+
+const slots2 = ah.getSlots(combatant2, 'action');
+assert.equal(slots2.length, 4);
+assert.equal(slots2[0].definition.slug, 'quickened'); // Quickened is first
+
+const log2 = [
+    { type: 'action', cost: 1, slug: 'stride' }, // Allowed in Quickened
+    { type: 'action', cost: 1, slug: 'stride' }, // Base
+    { type: 'action', cost: 1, slug: 'stride' }, // Base
+    { type: 'action', cost: 1, slug: 'cast-a-spell' } // Base
+];
+
+const result2 = ah.allocateSlots(combatant2, log2, 'action');
+assert.equal(result2.overspent.length, 0); // Fits perfectly
+assert.equal(result2.slots[0].spentBy, log2[0]); // Quickened slot takes Stride
+
+// Now what if the logs are in a different order?
+const log3 = [
+    { type: 'action', cost: 1, slug: 'cast-a-spell' }, // Base
+    { type: 'action', cost: 1, slug: 'stride' }, // Allowed in Quickened
+    { type: 'action', cost: 1, slug: 'stride' }, // Base
+    { type: 'action', cost: 1, slug: 'stride' } // Base
+];
+const result3 = ah.allocateSlots(combatant2, log3, 'action');
+assert.equal(result3.overspent.length, 0);
+// The Quickened slot (slots[0]) should be taken by the first eligible action, which is log3[1]
+assert.equal(result3.slots[0].spentBy, log3[1]);
+
+// Test 4: Overspend detection
+const log4 = [
+    { type: 'action', cost: 1, slug: 'cast-a-spell' }, // Base
+    { type: 'action', cost: 1, slug: 'cast-a-spell' }, // Base
+    { type: 'action', cost: 1, slug: 'cast-a-spell' }, // Base
+    { type: 'action', cost: 1, slug: 'cast-a-spell' }  // Overspend (Quickened doesn't allow cast-a-spell)
+];
+const result4 = ah.allocateSlots(combatant2, log4, 'action');
+assert.equal(result4.overspent.length, 1);
+assert.equal(result4.overspent[0], log4[3]);
+
+// Test 5: System drain overspend
+const log5 = [
+    { type: 'action', cost: 1, slug: 'stride' }, // Quickened
+    { type: 'action', cost: 1, slug: 'stride' }, // Base
+    { type: 'action', cost: 1, slug: 'stride' }, // Base
+    { type: 'system', cost: 1 } // System action consumes any slot. It should consume the 4th slot.
+];
+const result5 = ah.allocateSlots(combatant2, log5, 'action');
+assert.equal(result5.overspent.length, 0);
+assert.equal(result5.slots[3].spentBy.type, 'system');
+
+// Test 6: Slowed / Stunned overlap
+// Slowed 2 / Stunned 1
+// calculateStartOfTurnDrains returns actionsSpent = 2, reactionsSpent = 1
+const log6 = [
+    { type: 'system', cost: 2, msgId: 'System', label: 'Stunned 1 & Slowed 2' },
+    { type: 'action', cost: 1, slug: 'stride' }, // Takes 3rd slot
+    { type: 'action', cost: 1, slug: 'stride' }  // Takes 4th slot
+];
+const result6Action = ah.allocateSlots(combatant2, log6, 'action');
+const result6Reaction = ah.allocateSlots(combatant2, log6, 'reaction');
+
+assert.equal(result6Action.overspent.length, 0);
+assert.equal(result6Action.slots[0].spentBy.type, 'system'); // System drain takes Quickened first
+assert.equal(result6Action.slots[1].spentBy.type, 'system'); // System drain takes Base
+assert.equal(result6Action.slots[2].spentBy.slug, 'stride'); // Stride takes Base
+assert.equal(result6Action.slots[3].spentBy.slug, 'stride'); // Stride takes Base
+assert.equal(result6Reaction.overspent.length, 0);
+assert.equal(result6Reaction.slots[0].spentBy, undefined); // Reaction NOT drained since Stunned 1 <= maxActions
+
+// Slowed 1 / Stunned 0 and Quickened
+const log7 = [
+    { type: 'system', cost: 1, msgId: 'System', label: 'Slowed 1' },
+    { type: 'action', cost: 1, slug: 'stride' },
+    { type: 'action', cost: 1, slug: 'stride' },
+    { type: 'action', cost: 1, slug: 'stride' }
+];
+const result7 = ah.allocateSlots(combatant2, log7, 'action');
+assert.equal(result7.overspent.length, 0); // 1 system, 3 standard fit in 4 slots
+assert.equal(result7.slots[0].spentBy.type, 'system'); // System drain consumes Quickened
+assert.equal(result7.slots[1].spentBy.slug, 'stride');
+assert.equal(result7.slots[2].spentBy.slug, 'stride');
+assert.equal(result7.slots[3].spentBy.slug, 'stride');
+
+// Stunned 4 with Quickened (4 slots total)
+// maxActions = 4. stunnedVal = 4. 4 > 4 is false. Reaction NOT drained.
+const log8 = [
+    { type: 'system', cost: 4, msgId: 'System', label: 'Stunned 4' },
+    { type: 'action', cost: 1, slug: 'stride' } // Overspend! All 4 slots drained by Stunned
+];
+const result8Action = ah.allocateSlots(combatant2, log8, 'action');
+const result8Reaction = ah.allocateSlots(combatant2, log8, 'reaction');
+
+assert.equal(result8Action.overspent.length, 1);
+assert.equal(result8Action.slots[0].spentBy.type, 'system');
+assert.equal(result8Action.slots[1].spentBy.type, 'system');
+assert.equal(result8Action.slots[2].spentBy.type, 'system');
+assert.equal(result8Action.slots[3].spentBy.type, 'system');
+assert.equal(result8Reaction.overspent.length, 0);
+assert.equal(result8Reaction.slots[0].spentBy, undefined); // Reaction NOT drained! Stunned drops to 0.
+
+// Stunned 5 with Quickened (4 slots total)
+// maxActions = 4. stunnedVal = 5. 5 > 4 is true. Reaction IS drained!
+const log9 = [
+    { type: 'system', cost: 4, msgId: 'System', label: 'Stunned 5' },
+    { type: 'reaction', cost: 1, msgId: 'System', label: 'Stunned: Reaction Lost' }
+];
+const result9Action = ah.allocateSlots(combatant2, log9, 'action');
+const result9Reaction = ah.allocateSlots(combatant2, log9, 'reaction');
+
+assert.equal(result9Action.overspent.length, 0); // 4 actions drained perfectly
+assert.equal(result9Action.slots[0].spentBy.type, 'system');
+assert.equal(result9Reaction.overspent.length, 0);
+assert.equal(result9Reaction.slots[0].spentBy.msgId, 'System'); // Reaction drained!
+
+console.log("All slot allocation tests passed!");

--- a/src/ActionManager.ts
+++ b/src/ActionManager.ts
@@ -506,29 +506,53 @@ export class ActionManager {
         }
 
         // Reaction Drain
-        if (isParalyzed || stunnedVal > 0) {
-            reactionsSpent = (actor.system as any).resources?.reactions?.max || 1;
-            logEntries.push({ type: 'reaction', cost: 1, msgId: "System", label: `${isParalyzed ? 'Paralyzed' : 'Stunned'}: Reaction Lost`, isQuickenedEligible: false, category: "system", linkedMessages: [] });
+        if (isParalyzed || stunnedVal > maxActions) {
+            reactionsSpent = ActorHandler.getSlots(combatant, 'reaction').length;
+            logEntries.push({ type: 'reaction', cost: reactionsSpent, msgId: "System", label: `${isParalyzed ? 'Paralyzed' : 'Stunned'}: Reaction Lost`, isQuickenedEligible: false, category: "system", linkedMessages: [] });
         }
 
         return { logEntries, actionsSpent, reactionsSpent };
     }
 
-    static async refreshEconomyFromConditions(combatant: CombatantPF2e) {
+    /**
+     * Handles when conditions are dynamically added or removed mid-turn/off-turn.
+     * We only manage reaction drains here, because Action drains are resolved strictly at the start of a turn.
+     */
+    static async handleConditionChange(combatant: CombatantPF2e) {
         const c = combatant as any;
         const actor = c.actor as ActorPF2e | undefined;
         if (!actor) return;
 
-        const isQuickened = ActorHandler.getQuickenedState(combatant);
-        await c.update({
-            [`flags.${SCOPE}.isQuickenedSnapshot`]: isQuickened
-        });
+        const stunnedVal = ActorHandler.getConditionValue(actor, "stunned");
+        const isParalyzed = actor.hasCondition("paralyzed");
 
-        const { logEntries } = this.calculateStartOfTurnDrains(combatant, isQuickened);
-        const currentLog = [...this._getInternalLog(combatant)];
-        const mergedLog = [...logEntries, ...currentLog.filter(entry => entry.type !== "system")];
+        let log = [...this._getInternalLog(combatant)];
+        const reactionDrainIndex = log.findIndex(e => e.type === 'reaction' && e.category === 'system' && e.label.includes('Reaction Lost'));
 
-        await this._updateLogs(combatant, mergedLog, false);
+        const needsReactionDrain = isParalyzed || stunnedVal > 0;
+
+        let changed = false;
+
+        if (needsReactionDrain && reactionDrainIndex === -1) {
+            const reactionsSpent = ActorHandler.getSlots(combatant, 'reaction').length;
+            log.push({ 
+                type: 'reaction', 
+                cost: reactionsSpent, 
+                msgId: "System", 
+                label: `${isParalyzed ? 'Paralyzed' : 'Stunned'}: Reaction Lost`, 
+                isQuickenedEligible: false, 
+                category: "system", 
+                linkedMessages: [] 
+            });
+            changed = true;
+        } else if (!needsReactionDrain && reactionDrainIndex !== -1) {
+            log.splice(reactionDrainIndex, 1);
+            changed = true;
+        }
+
+        if (changed) {
+            await this._updateLogs(combatant, log, false);
+        }
     }
 
     /**
@@ -557,28 +581,13 @@ export class ActionManager {
         const actor = c.actor as ActorPF2e | null;
         if (!actor || !SettingsManager.get("whisperOverspend") || (game.user?.id !== game.users?.activeGM?.id)) return null;
 
-        const max = ActorHandler.getMaxActions(combatant); // Returns 3 or 4
-        const hasQuickened = ActorHandler.hasQuickenedSnapshot(combatant);
-
+        const { overspent } = ActorHandler.allocateSlots(combatant, newLogs, 'action');
+        
         const actionLog = newLogs.filter(e => e.type !== 'reaction');
         const rawTotalSpent = actionLog.reduce((sum, e) => sum + (e.cost || 0), 0);
 
-        // System actions (Slowed/Stunned) are inherently Quickened Eligible 
-        // because they are the first things to "drain" the pool.
-        const hasQuickenedEligible = actionLog.some(e => e.isQuickenedEligible && e.cost > 0);
-
-        let reason = "";
-
-        // --- Violation Check ---
-        if (rawTotalSpent > max) {
-            reason = `Spent ${rawTotalSpent} actions (Max: ${max})`;
-        }
-        else if (rawTotalSpent === max && hasQuickened && !hasQuickenedEligible) {
-            // They used the 4th slot, but nothing in their log is allowed to be there.
-            reason = `Bonus action used for an ineligible activity (e.g., must be Stride/Strike).`;
-        }
-
-        if (reason) {
+        if (overspent.length > 0) {
+            const reason = `Spent actions that exceeded available slots (${overspent.map(o => o.label).join(', ')}).`;
             const lastAlert = (c.getFlag(SCOPE, "lastOverspendAlert") as number) || 0;
             if (rawTotalSpent > lastAlert) {
                 await ChatManager.triggerAlert(actor, "Economy Alert", `**${actor.name}**: ${reason}`, 'whisperOverspend');
@@ -596,11 +605,11 @@ export class ActionManager {
         const actor = c.actor as ActorPF2e | null;
         if (!actor || !SettingsManager.get("whisperReactionOverspend") || game.user?.id !== game.users?.activeGM?.id) return;
 
-        const reactionLog = newLogs.filter(e => e.type === 'reaction');
-        const maxReactions = (actor.system as any).resources?.reactions?.max || 1;
+        const { overspent } = ActorHandler.allocateSlots(combatant, newLogs, 'reaction');
 
-        if (reactionLog.length > maxReactions) {
-            await ChatManager.triggerAlert(actor, "Economy Alert", `**${actor.name}**: Spent ${reactionLog.length} reactions with only ${maxReactions} available.`, 'whisperReactionOverspend');
+        if (overspent.length > 0) {
+            const reason = `Spent reactions that exceeded available slots (${overspent.map(o => o.label).join(', ')}).`;
+            await ChatManager.triggerAlert(actor, "Economy Alert", `**${actor.name}**: ${reason}`, 'whisperReactionOverspend');
         }
 
         return;

--- a/src/ActorHandler.ts
+++ b/src/ActorHandler.ts
@@ -1,5 +1,8 @@
-import { SCOPE } from "./globals";
-import { ActorPF2e, ConditionPF2e, CombatantPF2e } from "module-helpers";
+import { SCOPE } from "./globals.ts";
+import type { ActorPF2e, ConditionPF2e, CombatantPF2e } from "module-helpers";
+import type { ActionLogEntry } from "./ActionManager.ts";
+import { AddActionsLibrary } from "./addActionsData/AddActionsLibrary.ts";
+import type { ActionSlot } from "./addActionsData/types.d.ts";
 
 interface TurnSnapshot {
     isQuickened: boolean;
@@ -47,8 +50,18 @@ export class ActorHandler {
      * Calculates max actions for the turn for the player
      */
     static getMaxActions(combatant: CombatantPF2e, quickenedOverride?: boolean): number {
-        const isQuickened = quickenedOverride ?? this.hasQuickenedSnapshot(combatant);
-        return isQuickened ? 4 : 3;
+        // Dynamically calculate true max actions, including feats
+        const slots = this.getSlots(combatant, 'action');
+        let length = slots.length;
+
+        // If quickenedOverride is provided and differs from the current snapshot, adjust length
+        if (quickenedOverride !== undefined) {
+            const snapshot = this.hasQuickenedSnapshot(combatant);
+            if (quickenedOverride && !snapshot) length += 1;
+            if (!quickenedOverride && snapshot) length -= 1;
+        }
+
+        return length;
     }
 
     /**
@@ -109,5 +122,98 @@ export class ActorHandler {
      */
     static async cleanup(combatant: CombatantPF2e): Promise<void> {
         await (combatant as any).setFlag(SCOPE, "isQuickenedSnapshot", null);
+    }
+
+    /**
+     * Generates available Action or Reaction slots for the actor, sorted by restrictiveness.
+     */
+    static getSlots(combatant: CombatantPF2e, type: 'action' | 'reaction'): ActionSlot[] {
+        const slots: ActionSlot[] = [];
+        const actor = (combatant as any).actor;
+        if (!actor) return slots;
+
+        // 1. Generate Base Slots
+        if (type === 'action') {
+            const maxBase = 3;
+            for (let i = 0; i < maxBase; i++) {
+                slots.push({ isBase: true, type: 'action' });
+            }
+        } else {
+            const maxReactions = (actor.system as any).resources?.reactions?.max || 1;
+            for (let i = 0; i < maxReactions; i++) {
+                slots.push({ isBase: true, type: 'reaction' });
+            }
+        }
+
+        // 2. Generate Extra Slots
+        for (const [key, def] of Object.entries(AddActionsLibrary)) {
+            if (def.type !== type) continue;
+
+            let hasFeature = false;
+
+            // Special case for Quickened which uses a snapshot
+            if (key === 'quickened' && type === 'action') {
+                hasFeature = this.hasQuickenedSnapshot(combatant);
+            } else {
+                hasFeature = actor.items.some((i: any) => i.slug === key || i.system?.slug === key) || actor.hasCondition(key);
+            }
+
+            if (hasFeature) {
+                for (let i = 0; i < def.grants; i++) {
+                    slots.push({ isBase: false, type: type, definition: def });
+                }
+            }
+        }
+
+        // 3. Sort: Most restrictive first.
+        slots.sort((a, b) => {
+            if (a.isBase && !b.isBase) return 1; // Base goes last
+            if (!a.isBase && b.isBase) return -1;
+            if (a.isBase && b.isBase) return 0;
+
+            const aLen = a.definition?.allowedSlugs?.length ?? Infinity;
+            const bLen = b.definition?.allowedSlugs?.length ?? Infinity;
+            return aLen - bLen;
+        });
+
+        return slots;
+    }
+
+    /**
+     * Calculates which logged actions consume which slots, returning both the filled slots and any overspent actions.
+     */
+    static allocateSlots(combatant: CombatantPF2e, logs: ActionLogEntry[], type: 'action' | 'reaction'): { slots: ActionSlot[], overspent: ActionLogEntry[] } {
+        const slots = this.getSlots(combatant, type);
+        const overspent: ActionLogEntry[] = [];
+
+        // Filter logs by type (System drains also consume action slots)
+        const typeLogs = logs.filter(l => l.type === type || (type === 'action' && l.type === 'system'));
+
+        for (const log of typeLogs) {
+            // Reactions in PF2e often have cost: 0. We enforce they take 1 slot.
+            let costRemaining = type === 'reaction' ? Math.max(1, log.cost) : log.cost;
+
+            while (costRemaining > 0) {
+                const slotIndex = slots.findIndex(s => {
+                    if (s.spentBy) return false;
+                    if (s.isBase) return true;
+                    if (log.type === 'system' || log.msgId === 'System') return true;
+
+                    return s.definition?.allowedSlugs?.includes(log.slug || "") ?? false;
+                });
+
+                if (slotIndex !== -1) {
+                    slots[slotIndex].spentBy = log;
+                    costRemaining--;
+                } else {
+                    if (!overspent.includes(log)) {
+                        overspent.push(log);
+                    }
+                    costRemaining--;
+                }
+            }
+        }
+
+        return { slots, overspent };
     }
 }

--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -7,7 +7,6 @@ import { SocketsManager } from "./SocketManager";
 import { logConsole } from "./logger"
 import * as Detectors from "./chatTypeDetectors";
 import type { IActionDetails } from "./chatTypeDetectors/IActionDetector";
-import { logInfo } from "./logger";
 
 // Use a Template Literal Type for clarity, or just string
 type CombatantId = string;
@@ -484,8 +483,6 @@ export class ChatManager {
                 // Handle Whisper/Secret logic here globally
                 const isPublic = message.whisper.length === 0 || message.whisper.includes(game.user.id);
                 const finalLabel = isPublic ? details.label : "Secret Action";
-
-                logInfo(`Detected ${finalLabel} details: `, details, ' and Detector.type: ', Detector.type);
 
                 return {
                     cost: details.cost ?? 0,

--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -7,6 +7,7 @@ import { SocketsManager } from "./SocketManager";
 import { logConsole } from "./logger"
 import * as Detectors from "./chatTypeDetectors";
 import type { IActionDetails } from "./chatTypeDetectors/IActionDetector";
+import { logInfo } from "./logger";
 
 // Use a Template Literal Type for clarity, or just string
 type CombatantId = string;
@@ -483,6 +484,8 @@ export class ChatManager {
                 // Handle Whisper/Secret logic here globally
                 const isPublic = message.whisper.length === 0 || message.whisper.includes(game.user.id);
                 const finalLabel = isPublic ? details.label : "Secret Action";
+
+                logInfo(`Detected ${finalLabel} details: `, details, ' and Detector.type: ', Detector.type);
 
                 return {
                     cost: details.cost ?? 0,

--- a/src/CombatUIManager.ts
+++ b/src/CombatUIManager.ts
@@ -51,10 +51,13 @@ export class CombatUIManager {
         const log = (c.getFlag(SCOPE, "log") as ActionLogEntry[]) || [];
         const flattenedLog = ActionManager.getFlattenedActions(combatant);
 
-        const isQuickened = ActorHandler.hasQuickenedSnapshot(combatant);
+        const actionSlotsForRenderKey = ActorHandler.getSlots(combatant, 'action');
+        const reactionSlotsForRenderKey = ActorHandler.getSlots(combatant, 'reaction');
+
+        const actionSlotsKey = actionSlotsForRenderKey.map(s => s.definition?.slug || 'base').join(',');
         const currentMAP = ActionManager.getCurrentMAP(combatant);
         const mapDisplay = getMapDisplayState(currentMAP);
-        const maxReactions = (actor.system as any).resources?.reactions?.max || 1;
+        const maxReactions = reactionSlotsForRenderKey.length;
         const renderKeyLog = flattenedLog.map(entry => {
             const message = game.messages.get(entry.msgId || "");
             const visibilityKey = message
@@ -68,7 +71,7 @@ export class CombatUIManager {
             isGM,
             isOwner,
             isPC,
-            isQuickened,
+            actionSlotsKey,
             mapAttackCount: currentMAP.attackCount,
             maxReactions,
             log: renderKeyLog,
@@ -83,29 +86,44 @@ export class CombatUIManager {
         const charMap: Record<string, string> = { "1": "A", "2": "D", "3": "T" };
 
         // --- 1. Allocation Logic ---
-        const actions = log.filter(e => e.type !== 'reaction');
-        let quickenedSlot: { entry: ActionLogEntry, index: number } | null = null;
-        const standardSlots: { entry: ActionLogEntry, index: number, subIndex: number }[] = [];
-        const overspendSlots: { entry: ActionLogEntry, index: number, subIndex: number }[] = [];
+        const { slots: actionSlots, overspent: overspentActions } = ActorHandler.allocateSlots(combatant, log, 'action');
 
-        for (const [index, entry] of actions.entries()) {
-            let costRemaining = entry.cost;
-            const canUseQuickened = entry.isQuickenedEligible;
+        const pipsToRender: { entry: ActionLogEntry, slot?: any, isGold: boolean, isOver: boolean, subIdx: number, totalCost: number }[] = [];
 
-            // A: Fill Quickened Slot first if eligible
-            if (isQuickened && !quickenedSlot && canUseQuickened) {
-                quickenedSlot = { entry, index };
-                costRemaining -= 1;
+        for (const slot of actionSlots) {
+            if (slot.spentBy) {
+                const subIdx = pipsToRender.filter(p => p.entry === slot.spentBy).length;
+                pipsToRender.push({
+                    entry: slot.spentBy,
+                    slot,
+                    isGold: !slot.isBase,
+                    isOver: false,
+                    subIdx,
+                    totalCost: slot.spentBy.cost
+                });
+            } else {
+                pipsToRender.push({
+                    entry: null as any,
+                    slot,
+                    isGold: !slot.isBase,
+                    isOver: false,
+                    subIdx: 0,
+                    totalCost: 1
+                });
             }
+        }
 
-            // B: Distribute the REST of the cost to standard or overspend
-            for (let i = 0; i < costRemaining; i++) {
-                const subIdx = entry.cost - costRemaining + i;
-                if (standardSlots.length < maxStandardActions) {
-                    standardSlots.push({ entry, index, subIndex: subIdx });
-                } else {
-                    overspendSlots.push({ entry, index, subIndex: subIdx });
-                }
+        for (const entry of overspentActions) {
+            const assignedPips = pipsToRender.filter(p => p.entry === entry).length;
+            const remainingCost = entry.cost - assignedPips;
+            for (let i = 0; i < remainingCost; i++) {
+                pipsToRender.push({
+                    entry,
+                    isGold: false,
+                    isOver: true,
+                    subIdx: assignedPips + i,
+                    totalCost: entry.cost
+                });
             }
         }
 
@@ -129,12 +147,36 @@ export class CombatUIManager {
         /**
          * Helper to render individual pips with correct PF2e Action Symbols
          */
-        const renderPip = (entry: ActionLogEntry, idx: number, subIdx: number, isGold: boolean, isOver: boolean) => {
+        const renderPip = (pip: any) => {
 
             if (pipsRendered >= MAX_PIPS) {
-                overflowCount++;
+                if (pip.isOver) overflowCount++;
                 return;
             }
+
+            if (!pip.entry) {
+                // Unspent
+                const span = document.createElement("span");
+                span.className = `action-icon unspent ${pip.isGold ? 'quickened' : ''} tracker-tooltip`;
+
+                let tooltip = "Available Action";
+                if (pip.slot && pip.slot.definition) {
+                    tooltip = `Available Action (${pip.slot.definition.name})`;
+                } else if (pip.isGold) {
+                    tooltip = "Available Bonus Action";
+                }
+
+                span.dataset.tooltip = tooltip;
+                span.textContent = "A";
+                actionLine.appendChild(span);
+                pipsRendered++;
+                return;
+            }
+
+            const entry = pip.entry;
+            const isGold = pip.isGold;
+            const isOver = pip.isOver;
+            const subIdx = pip.subIdx;
 
             const message = game.messages.get(entry.msgId || "");
 
@@ -158,13 +200,19 @@ export class CombatUIManager {
 
             // 2. Logic for Icons (A, D, T)
             let iconChar = "";
+
             if (isGold) {
-                iconChar = "A";
+                iconChar = "A"; // Gold slots always remain entirely separate single pips
             } else {
-                const siblingPips = [...standardSlots, ...overspendSlots].filter(s => s.index === idx);
-                const firstSubIdxInGroup = siblingPips[0]?.subIndex ?? -1;
-                if (subIdx === firstSubIdxInGroup) {
-                    iconChar = charMap[siblingPips.length.toString()] || "A";
+                // Determine how many NON-GOLD pips this entry consumes, and which one this is.
+                // This allows multi-actions that span Gold + Normal slots to safely isolate the Gold pip
+                // and then "combine normally" across the remaining Normal pips.
+                const normalPipsForEntry = pipsToRender.filter(p => p.entry === entry && !p.isGold);
+                const normalTotalCost = normalPipsForEntry.length;
+                const normalSubIdx = normalPipsForEntry.indexOf(pip);
+
+                if (normalSubIdx === 0) {
+                    iconChar = charMap[normalTotalCost.toString()] || "A";
                 }
             }
 
@@ -185,7 +233,11 @@ export class CombatUIManager {
 
             } else {
                 // Normal behavior for those with permission
-                span.dataset.tooltip = `Used: ${displayLabel}${isGold ? ' (Bonus Action)' : ''}${isOver ? ' (Overspent)' : ''}`;
+                let suffix = '';
+                if (pip.slot && pip.slot.definition) suffix = ` (${pip.slot.definition.name})`;
+                else if (isGold) suffix = ` (Bonus Action)`;
+
+                span.dataset.tooltip = `Used: ${displayLabel}${suffix}${isOver ? ' (Overspent)' : ''}`;
 
                 if (entry.type === "system" || entry.msgId === "System") {
                     span.style.cursor = "default";
@@ -201,7 +253,7 @@ export class CombatUIManager {
             actionLine.appendChild(span);
             pipsRendered++;
 
-            if (isOver && subIdx === entry.cost - 1) {
+            if (isOver && subIdx === pip.totalCost - 1) {
                 const warn = document.createElement("span");
                 warn.className = "overspend-exclamation";
                 warn.textContent = "!";
@@ -210,19 +262,12 @@ export class CombatUIManager {
         };
 
         // --- 3. Build the DOM ---
+        for (let i = 0; i < pipsToRender.length; i++) {
+            const pip = pipsToRender[i];
+            renderPip(pip);
 
-        // Render Quickened Slot
-        if (isQuickened) {
-            if (quickenedSlot) {
-                renderPip(quickenedSlot.entry, quickenedSlot.index, 0, true, false);
-            } else {
-                const span = document.createElement("span");
-                span.className = "action-icon unspent quickened tracker-tooltip";
-                span.dataset.tooltip = "Quickened Action (Available)";
-                span.textContent = "A";
-                actionLine.appendChild(span);
-            }
-            if (!isCompact) {
+            // Add divider if transitioning from gold to non-gold
+            if (pip.isGold && !isCompact && i < pipsToRender.length - 1 && !pipsToRender[i + 1].isGold) {
                 const divider = document.createElement("span");
                 divider.className = "divider";
                 divider.textContent = "|";
@@ -230,29 +275,10 @@ export class CombatUIManager {
             }
         }
 
-        // Render Standard (Spent)
-        standardSlots.forEach(s => renderPip(s.entry, s.index, s.subIndex, false, false));
-
-        // Render Standard (Unspent)
-        const unspentCount = maxStandardActions - standardSlots.length;
-        for (let i = 0; i < unspentCount; i++) {
-            if (pipsRendered >= MAX_PIPS) break; // Don't show unspent pips if we are already full
-            pipsRendered++;
-
-            const span = document.createElement("span");
-            span.className = "action-icon unspent tracker-tooltip";
-            span.dataset.tooltip = "Available Action";
-            span.textContent = "A";
-            actionLine.appendChild(span);
-        }
-
-        // Render Overspend
+        // Render Overspend Overflow Indicator
         let compactOverspend = false;
         if (isCompact) {
-            overflowCount += overspendSlots.length;
             compactOverspend = hasCompactOverspendTint(overflowCount);
-        } else {
-            overspendSlots.forEach(s => renderPip(s.entry, s.index, s.subIndex, false, true));
         }
 
         // Render Overflow Indicator
@@ -318,8 +344,7 @@ export class CombatUIManager {
         container.appendChild(actionLine);
 
         // --- 4. Reactions Line ---
-        const fullLog = ActionManager.getActions(combatant); // Get the original full log
-        const reactionLog = fullLog.filter(e => e.type === 'reaction');
+        const { slots: reactionSlots } = ActorHandler.allocateSlots(combatant, log, 'reaction');
 
         const reactionLine = document.createElement("div");
         reactionLine.className = `reaction-line ${isCompact ? 'compact' : ''}`.trim();
@@ -332,22 +357,33 @@ export class CombatUIManager {
             actionLine.appendChild(divider);
         }
 
-        for (let i = 0; i < maxReactions; i++) {
-            const entry = reactionLog[i];
+        reactionSlots.forEach(slot => {
             const span = document.createElement("span");
+            const entry = slot.spentBy;
             span.className = `action-icon reaction ${entry ? 'spent' : 'unspent'} tracker-tooltip`;
-            span.dataset.tooltip = entry?.label || 'Reaction Available';
+
+            let tooltip = 'Reaction Available';
+            if (entry) {
+                let suffix = '';
+                if (slot.definition) suffix = ` (${slot.definition.name})`;
+                tooltip = `Used: ${entry.label}${suffix}`;
+            } else if (slot.definition) {
+                tooltip = `Available Reaction (${slot.definition.name})`;
+            }
+
+            span.dataset.tooltip = tooltip;
             span.textContent = "R";
 
             if (entry) {
-                // Find the index of this entry in the ORIGINAL log for the context menu handler
+                const fullLog = ActionManager.getActions(combatant);
                 const originalIndex = fullLog.findIndex(e => e.msgId === entry.msgId);
                 span.dataset.msgId = entry.msgId;
                 span.dataset.index = originalIndex.toString();
             }
 
             (isCompact ? actionLine : reactionLine).appendChild(span);
-        }
+        });
+
         if (!isCompact && mapDisplay.core.text) {
             const divider = document.createElement("span");
             divider.className = "divider";

--- a/src/addActionsData/AddActionsLibrary.ts
+++ b/src/addActionsData/AddActionsLibrary.ts
@@ -1,0 +1,39 @@
+import type { ExtraSlotDefinition } from "./types";
+
+export const AddActionsLibrary: Record<string, ExtraSlotDefinition> = {
+    "quickened": {
+        name: "Quickened",
+        slug: "quickened",
+        type: "action",
+        grants: 1,
+        allowedSlugs: ["strike", "stride", "step", "interact", "sustain-a-spell"]
+    },
+    "tactical-reflexes": {
+        name: "Tactical Reflexes",
+        slug: "tactical-reflexes",
+        type: "reaction",
+        grants: 1,
+        allowedSlugs: ["reactive-strike"]
+    },
+    "combat-reflexes": {
+        name: "Combat Reflexes",
+        slug: "combat-reflexes",
+        type: "reaction",
+        grants: 1,
+        allowedSlugs: ["reactive-strike"]
+    },
+    "divine-reflexes": {
+        name: "Divine Reflexes",
+        slug: "divine-reflexes",
+        type: "reaction",
+        grants: 1,
+        allowedSlugs: ["retributive-strike", "glimpse-of-redemption", "liberating-step", "iron-command", "selfish-shield", "destructive-vengeance"]
+    },
+    "esoteric-reflexes": {
+        name: "Esoteric Reflexes",
+        slug: "esoteric-reflexes",
+        type: "reaction",
+        grants: 1,
+        allowedSlugs: ["implements-interruption", "amulets-abeyance", "bells-disruption"]
+    }
+};

--- a/src/addActionsData/types.d.ts
+++ b/src/addActionsData/types.d.ts
@@ -1,0 +1,16 @@
+import { ActionLogEntry } from "../ActionManager";
+
+export interface ExtraSlotDefinition {
+    name: string;            // e.g., "Opportune Attack"
+    slug: string;            // Feat/Item/Condition slug (e.g., "opportune-attack", "quickened")
+    type: 'action' | 'reaction';
+    grants: number;
+    allowedSlugs?: string[];
+}
+
+export interface ActionSlot {
+    isBase: boolean;
+    type: 'action' | 'reaction';
+    definition?: ExtraSlotDefinition;
+    spentBy?: ActionLogEntry; // Null if unused
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,9 +235,60 @@ Hooks.on("updateToken", (tokenDoc: any, update: any) => {
     if (!("x" in update || "y" in update || update.movementAction)) return;
 
     const combatant: Combatant = tokenDoc.combatant;
-    if (!combatant.id) return;
+    if (!combatant?.id) return;
 
     enqueueAction(combatant.id, async () => await MovementManager.handleTokenUpdate(tokenDoc, update));
+});
+
+// Condition Hooks for dynamic Reaction Loss
+Hooks.on("createItem", async (item: any) => {
+    if (game.user?.id !== game.users?.activeGM?.id) return;
+    if (item.type !== "condition" && item.type !== "effect") return;
+
+    if (item.slug === "stunned" || item.slug === "paralyzed") {
+        const actor = item.parent;
+        if (!actor) return;
+
+        const combatant = game.combat?.combatants.find((c: any) => c.actorId === actor.id);
+        const c = combatant as unknown as Combatant
+        if (!c?.id || !combatant) return;
+
+        enqueueAction(c.id, async () => await ActionManager.handleConditionChange(combatant));
+    }
+});
+
+Hooks.on("updateItem", async (item: any, updateData: any) => {
+    if (game.user?.id !== game.users?.activeGM?.id) return;
+    if (item.type !== "condition" && item.type !== "effect") return;
+
+    if (item.slug === "stunned" || item.slug === "paralyzed") {
+        if (updateData.system?.value !== undefined) {
+            const actor = item.parent;
+            if (!actor) return;
+
+            const combatant = game.combat?.combatants.find((c: any) => c.actorId === actor.id);
+            const c = combatant as unknown as Combatant
+            if (!c?.id || !combatant) return;
+
+            enqueueAction(c.id, async () => await ActionManager.handleConditionChange(combatant));
+        }
+    }
+});
+
+Hooks.on("deleteItem", async (item: any) => {
+    if (game.user?.id !== game.users?.activeGM?.id) return;
+    if (item.type !== "condition" && item.type !== "effect") return;
+
+    if (item.slug === "stunned" || item.slug === "paralyzed") {
+        const actor = item.parent;
+        if (!actor) return;
+
+        const combatant = game.combat?.combatants.find((c: any) => c.actorId === actor.id);
+        const c = combatant as unknown as Combatant
+        if (!c?.id || !combatant) return;
+
+        enqueueAction(c.id, async () => await ActionManager.handleConditionChange(combatant));
+    }
 });
 
 export async function enqueueAction(combatantId: string, actionFn: () => Promise<void>) {

--- a/src/trackerAdapters.ts
+++ b/src/trackerAdapters.ts
@@ -83,7 +83,7 @@ export function getTrackerRenderKey({
     isGM,
     isOwner,
     isPC,
-    isQuickened,
+    actionSlotsKey,
     mapAttackCount,
     maxReactions,
     log,
@@ -93,7 +93,7 @@ export function getTrackerRenderKey({
     isGM: boolean;
     isOwner: boolean;
     isPC: boolean;
-    isQuickened: boolean;
+    actionSlotsKey: string;
     mapAttackCount: number;
     maxReactions: number;
     log: RenderKeyEntry[];
@@ -116,7 +116,7 @@ export function getTrackerRenderKey({
         `gm:${isGM ? 1 : 0}`,
         `owner:${isOwner ? 1 : 0}`,
         `pc:${isPC ? 1 : 0}`,
-        `quick:${isQuickened ? 1 : 0}`,
+        `slots:${actionSlotsKey}`,
         `map:${mapAttackCount}`,
         `reactions:${maxReactions}`,
         entries,


### PR DESCRIPTION
…/reactions - fix reaction removal to RAW

## 🚀 Automated Action Tracker - Release PR

### 📋 Pre-Merge Checklist
- [ X ] **Version Bump:** I have updated the version in `package.json` (Current: ).
- [ X ] **Local Check:** The `dist/main.js` has been built and looks correct.
- [ X ] **Issue Linking:** This PR closes the issue listed below.

### 🔗 Associated Issue
Closes #32 Closes #34 

### 📝 Change Summary
- Add mid-turn condition tracking to update reaction loss/un-loss appropriately to follow RAW
- Added extensible library for feats that give reactions
-   - Added support for Tactical Reflexes, Combat Reflexes, Divine Reflexes, and Esoteric Reflexes
- Change how actions and reactions are dynamically allocated in the UI
- Added automated testing for slowed and stunned.