### PR TITLE
Change where our sustain reminder UUID is being stored from standard …

### DIFF
--- a/MOVEMENT.md
+++ b/MOVEMENT.md
@@ -51,3 +51,5 @@ Yes. Both modes use Foundry's path measurement. If you move from Square A to Squ
 
 **Why is my Stride entry increasing as I move?**
 Both modes try to be smart about your action economy. If you are in the middle of a move, the tracker will update the current "Stride" entry's distance and cost in real-time rather than cluttering your log with multiple 5ft Stride actions.
+
+If in the middle of a Complex Action that allows actions in the middle of movement (such as Dual-Weapon Blitz), this will try to maximize your allotted movement within the move action.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2e-auto-action-tracker",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -383,13 +383,12 @@ export class ChatManager {
                 alias: actor.name
             },
             flavor: `<h4 class="action"><strong>Sustain</strong> <span class="action-glyph">1</span></h4>`,
-            content: `<div class="pf2e">Sustaining <strong>${displayName}</strong></div>`,
+            content: `<div class="pf2e">Sustaining <strong>@UUID[${item?.uuid}]{${displayName}}</strong></div>`,
             flags: {
                 pf2e: {
                     origin: {
-                        uuid: item?.uuid,
                         name: displayName,
-                        type: item?.type || "item",
+                        type: "action",
                         slug: "sustain-a-spell"
                     },
                     context: {
@@ -401,6 +400,7 @@ export class ChatManager {
                 [SCOPE]: {
                     isSustainAutomation: true,
                     sustainedItemId: itemId,
+                    sustainedItemUuid: item?.uuid,
                     sustainedItemName: displayName
                 }
             }

--- a/src/chatTypeDetectors/SustainDetector.ts
+++ b/src/chatTypeDetectors/SustainDetector.ts
@@ -36,9 +36,10 @@ export class SustainDetector {
         // ID Extraction
         let itemId = customFlags.sustainedItemId;
 
-        // Fallback 1: Try the Origin UUID (Standard PF2e way)
-        if (!itemId && flags.origin?.uuid) {
-            const originItem = fromUuidSync(flags.origin.uuid) as any;
+        // Fallback 1: Try our custom UUID or the Origin UUID (Standard PF2e way)
+        const originUuid = customFlags.sustainedItemUuid || flags.origin?.uuid;
+        if (!itemId && originUuid) {
+            const originItem = fromUuidSync(originUuid) as any;
             itemId = originItem?.id;
         }
 
@@ -51,7 +52,7 @@ export class SustainDetector {
         const itemName = customFlags.sustainedItemName ||
             flags.casting?.embeddedSpell?.name ||
             message.item?.name ||
-            (flags.origin?.uuid ? (fromUuidSync(flags.origin.uuid) as any)?.name : null) ||
+            (originUuid ? (fromUuidSync(originUuid) as any)?.name : null) ||
             "Action";
 
         return { itemId, itemName };

--- a/src/main.ts
+++ b/src/main.ts
@@ -151,7 +151,8 @@ Hooks.on("preCreateChatMessage", (message: any) => {
     const intentItemId = recentIntent.get(uniqueKey);
 
     // PF2e uses origin.uuid for item links in chat
-    const messageItemId = message.flags?.pf2e?.origin?.uuid?.split('.').pop();
+    const originUuid = message.flags?.[SCOPE]?.sustainedItemUuid || message.flags?.pf2e?.origin?.uuid;
+    const messageItemId = message.flags?.[SCOPE]?.sustainedItemId || originUuid?.split('.').pop();
 
     if (intentItemId && intentItemId === messageItemId) {
         message.updateSource({


### PR DESCRIPTION
…PF2E place to our custom module's place

## 🚀 Automated Action Tracker - Release PR

### 📋 Pre-Merge Checklist
- [ x ] **Version Bump:** I have updated the version in `package.json` (Current: ).
- [ x ] **Local Check:** The `dist/main.js` has been built and looks correct.
- [ x ] **Issue Linking:** This PR closes the issue listed below.

### 🔗 Associated Issue
Closes #47 

### 📝 Change Summary
- Change sustain reminder UUID from pf2e.origin.UUID to our custom UUID location
- Add documentation missed for MOVEMENT.md