### PR TITLE
feat: migrate renderChatMessage hook to renderChatMessageHTML for V14/V15

### DIFF
--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -214,57 +214,64 @@ export class ChatManager {
     /**
      * Handles rendering of the chat messages for our custom sustain spells - and adds the onClick logic for the buttons in it
      */
-    static onRenderChatMessage(message: any, html: JQuery) {
-        const sustainButtons = html.find("button[data-action^='sustain-']");
+    static onRenderChatMessage(message: any, html: HTMLElement) {
+        const sustainButtons = html.querySelectorAll<HTMLButtonElement>("button[data-action^='sustain-']");
         if (sustainButtons.length === 0) return;
 
         const choiceData = message.getFlag(SCOPE, "sustainChoice") as { choice: string, itemName: string };
 
         if (choiceData) {
-            const card = html.find('.pf2e-auto-action-tracker-sustain-card');
-            if (choiceData.choice === 'yes') {
-                card.find("button[data-action='sustain-yes']").html('<i class="fas fa-check"></i> Sustained').prop('disabled', true);
-                card.find("button[data-action='sustain-no']").hide();
+            const card = html.querySelector(".pf2e-auto-action-tracker-sustain-card");
+            if (!card) return;
+            const yesBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-yes']");
+            const noBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-no']");
+            if (!yesBtn || !noBtn) return;
+            if (choiceData.choice === "yes") {
+                yesBtn.innerHTML = '<i class="fas fa-check"></i> Sustained';
+                yesBtn.disabled = true;
+                noBtn.style.display = "none";
             } else {
-                card.find("button[data-action='sustain-no']").html('<i class="fas fa-times"></i> Lapsed').prop('disabled', true);
-                card.find("button[data-action='sustain-yes']").hide();
+                noBtn.innerHTML = '<i class="fas fa-times"></i> Lapsed';
+                noBtn.disabled = true;
+                yesBtn.style.display = "none";
             }
             return;
         }
 
-        sustainButtons.on("click", async (event) => {
-            event.preventDefault();
-            const button = event.currentTarget;
-            const { action, actorId, itemId, itemName, combatantId } = button.dataset;
- 
-            const actor = (game.actors as any).get(actorId ?? "");
-            if (!actor || (!actor.isOwner && !game.user.isGM)) return;
- 
-            // Resolve the combatant directly by ID (Identity Crisis Solved)
-            const combatant = game.combat?.combatants.get(combatantId || "");
- 
-            const choice = action === "sustain-yes" ? "yes" : "no";
-            const payload = {
-                messageId: message.id,
-                actorId: actor.id,
-                combatantId: combatantId, // Pass this to the socket
-                itemId: itemId || "",
-                itemName: itemName || "",
-                choice: choice
-            };
- 
-            if (game.user.isGM) {
-                if (choice === "yes") {
-                    await this.processSustainYes(actor, itemId || "", itemName || "", combatantId);
+        sustainButtons.forEach((button) => {
+            button.addEventListener("click", async (event) => {
+                event.preventDefault();
+                const { action, actorId, itemId, itemName, combatantId } = button.dataset;
+
+                const actor = (game.actors as any).get(actorId ?? "");
+                if (!actor || (!actor.isOwner && !game.user.isGM)) return;
+
+                // Resolve the combatant directly by ID (Identity Crisis Solved)
+                const combatant = game.combat?.combatants.get(combatantId || "");
+
+                const choice = action === "sustain-yes" ? "yes" : "no";
+                const payload = {
+                    messageId: message.id,
+                    actorId: actor.id,
+                    combatantId: combatantId, // Pass this to the socket
+                    itemId: itemId || "",
+                    itemName: itemName || "",
+                    choice: choice
+                };
+
+                if (game.user.isGM) {
+                    if (choice === "yes") {
+                        await this.processSustainYes(actor, itemId || "", itemName || "", combatantId);
+                    } else {
+                        // Pass the specific combatant found via ID
+                        await this.processSustainNo(actor, itemId || "", combatant);
+                    }
+                    await (message as any).setFlag(SCOPE, "sustainChoice", { choice, itemName });
                 } else {
-                    // Pass the specific combatant found via ID
-                    await this.processSustainNo(actor, itemId || "", combatant);
+                    const { SocketsManager } = await import("./SocketManager.ts");
+                    SocketsManager.emitSustainChoice(payload);
                 }
-                await (message as any).setFlag(SCOPE, "sustainChoice", { choice, itemName });
-            } else {
-                const { SocketsManager } = await import("./SocketManager.ts");
-                SocketsManager.emitSustainChoice(payload);
-            }
+            });
         });
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,8 +162,9 @@ Hooks.on("preCreateChatMessage", (message: any) => {
     }
 });
 
-// Rendering the chat message
-Hooks.on("renderChatMessage", (message: ChatMessagePF2e, html: any) => {
+// Rendering the chat message — v13+ uses renderChatMessageHTML (HTMLElement); legacy renderChatMessage hook
+// is deprecated since v13 and removed in v15.
+Hooks.on("renderChatMessageHTML", (message: ChatMessagePF2e, html: HTMLElement) => {
     // Does not need enqueuing - This only create messages and click handlers -> which creates more messages.  So no
     // modifications of actions here
     ChatManager.onRenderChatMessage(message, html);


### PR DESCRIPTION
## Summary

Switches the sustain-spell reminder rendering from the deprecated `renderChatMessage` hook to its V13+ replacement `renderChatMessageHTML`, and rewrites `ChatManager.onRenderChatMessage` to use vanilla DOM APIs instead of jQuery.

## Why

In Foundry V14 (verified on stable build 14.360, source at `client/documents/chat-message.mjs:430-435`), the legacy `renderChatMessage` hook is fired only as a back-compat path when a listener is registered, and it logs:

> The renderChatMessage hook is deprecated. Please use renderChatMessageHTML instead, which now passes an HTMLElement argument instead of jQuery. (since: 13, until: 15)

So today the module emits a deprecation warning on every chat render, and on V15 the hook stops firing entirely — the Sustain / Let-Lapse buttons would silently lose their click handlers and the post-choice button states (`Sustained` ✓ / `Lapsed` ✗) would no longer render on re-display.

## Changes

- `src/main.ts` — rename the hook from `renderChatMessage` to `renderChatMessageHTML` and type the second arg as `HTMLElement`.
- `src/ChatManager.ts` — rewrite `onRenderChatMessage(message, html: HTMLElement)`:
  - `html.find(...)` → `html.querySelectorAll(...)` / `querySelector(...)`
  - `.html(str)` → `.innerHTML = str`
  - `.prop("disabled", true)` → `.disabled = true`
  - `.hide()` → `.style.display = "none"`
  - `sustainButtons.on("click", h)` → `sustainButtons.forEach(btn => btn.addEventListener("click", h))`

The DOM scope touched is entirely inside the module-owned `.pf2e-auto-action-tracker-sustain-card` element (template at `public/templates/sustain-reminder.hbs`), so no other modules' jQuery handlers are affected.

This handler is the only site in the codebase subscribing to the deprecated hook — no other call sites need updating.

## Relationship to #51

Independent of #51 — this change touches different lines than #51 does and applies cleanly on top of `main`. It complements #51's compatibility-shim approach: #51 covers the V14.360 bump and `ui.windows`/`isActiveGM`/`renderTemplate` shims, this covers the v13/v15 hook migration. Either order works; both should land for full V14 cleanliness and V15 forward-compat.

## Test plan

- [x] Build (`npm run build`) clean — bundle includes `Hooks.on("renderChatMessageHTML", ...)` and zero occurrences of `Hooks.on("renderChatMessage", ...)`.
- [x] Bundle is syntactically valid JS (`node --check dist/main.js`).
- [x] Deployed to a Foundry V14.360 + PF2E 8.1.1 install for verification.
- [ ] In V14: cast a sustained spell on a combatant's turn → end turn → click **Sustain** on the auto-posted reminder card → button text changes to "Sustained" with checkmark, "Let Lapse" hides.
- [ ] Reload the page → re-rendered card shows the chosen state (verifies the `choiceData` branch).
- [ ] Repeat with **Let Lapse** → button text changes to "Lapsed", "Sustain" hides.
- [ ] Non-GM client clicks Sustain on their character's card → socketlib forwards to GM and processing happens.
- [ ] Browser console contains **no** `renderChatMessage hook is deprecated` warning.