### PR TITLE
fix: post-V14 resilience and cleanup (memory leaks, libWrapper guards, dead code)

### DIFF
--- a/src/WrapperManager.ts
+++ b/src/WrapperManager.ts
@@ -1,5 +1,5 @@
 import { ChatManager } from "./ChatManager";
-import { logConsole } from "./logger";
+import { logConsole, logWarn } from "./logger";
 import { recentIntent } from "./globals";
 
 declare const libWrapper: any;
@@ -13,8 +13,20 @@ export class WrapperManager {
             return;
         }
 
+        // Each registration is wrapped individually so that a missing or renamed PF2E target
+        // (e.g. after a system update) only disables that one feature instead of throwing out
+        // of `wrapFunctions` and leaving the remaining wraps unregistered.
+        const tryRegister = (target: string, fn: any) => {
+            try {
+                libWrapper.register("pf2e-auto-action-tracker", target, fn, "WRAPPER");
+            } catch (e) {
+                const reason = (e instanceof Error ? e.message : String(e)) || "unknown error";
+                logWarn(`libWrapper failed to wrap ${target}: ${reason}. Related tracking will be disabled.`);
+            }
+        };
+
         // Wrap the Check.rerollFromMessage to log the old message ID from a message being rerolled.  Used to track which action to update once the reroll happens
-        libWrapper.register("pf2e-auto-action-tracker", "game.pf2e.Check.rerollFromMessage", function (this: any, wrapped: Function, ...args: any[]) {
+        tryRegister("game.pf2e.Check.rerollFromMessage", function (this: any, wrapped: Function, ...args: any[]) {
             const message = args[0];
             if (message?.id) {
                 const speaker = message.speaker;
@@ -27,11 +39,10 @@ export class WrapperManager {
                 }
             }
             return wrapped.apply(this, args);
-        }, "WRAPPER");
+        });
 
         // Wrapper for tracking spell casting (as opposed to spell linking)
-        libWrapper.register(
-            "pf2e-auto-action-tracker",
+        tryRegister(
             "CONFIG.PF2E.Item.documentClasses.spellcastingEntry.prototype.cast",
             async function (this: any, wrapped: Function, spell: any, options: any = {}) {
                 const actor = this.actor;
@@ -43,13 +54,11 @@ export class WrapperManager {
                 }
 
                 return wrapped(spell, options);
-            },
-            "WRAPPER"
+            }
         );
 
         // Wrapper for tracking consumable using (as opposed to consumable linking)
-        libWrapper.register(
-            "pf2e-auto-action-tracker",
+        tryRegister(
             "CONFIG.PF2E.Item.documentClasses.consumable.prototype.consume",
             async function (this: any, wrapped: Function, ...args: any[]) {
                 const actor = this.actor;
@@ -60,8 +69,7 @@ export class WrapperManager {
                     recentIntent.set(uniqueKey, this.id);
                 }
                 return wrapped(...args);
-            },
-            "WRAPPER"
+            }
         );
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,6 +298,14 @@ Hooks.on("updateToken", (tokenDoc: any, update: any, options: any, userId: strin
     enqueueAction(combatant.id, async () => await MovementManager.handleTokenUpdate(tokenDoc, update, options));
 });
 
+// Drop captured movement state for tokens that leave the scene. The MovementManager keeps
+// per-token Maps (_capturedHistory, _historyLengths, _lastCoords, _lastInteractionDistance)
+// that are never otherwise pruned for deleted tokens, so without this hook those Maps grow
+// across long campaigns as tokens come and go.
+Hooks.on("deleteToken", (tokenDoc: any) => {
+    if (tokenDoc?.id) MovementManager.resetCapturedHistory(tokenDoc.id);
+});
+
 // Condition Hooks for dynamic Reaction Loss
 Hooks.on("createItem", async (item: any) => {
     if (game.user?.id !== game.users?.activeGM?.id) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,11 +73,7 @@ Hooks.on("closeDamageModifierDialog", async (app: any) => {
         delete (app.actor as any)._lastDamageOriginId;
     }
 
-    // 2. If the dialog closed because they rolled, the message creation 
-    // logic already handled the queue/flags.
-    if (app.element?.[0]?._wasRolled) return;
-
-    // 3. Find the combatant
+    // 2. Find the combatant
     const tokenId = app.token?.id;
     const actorId = app.actor?.id;
 
@@ -88,7 +84,7 @@ Hooks.on("closeDamageModifierDialog", async (app: any) => {
     const c = combatant as any;
     if (!c?.id || !combatant) return;
 
-    // 4. Safety cleanup is a write operation, enqueue it
+    // 3. Safety cleanup is a write operation, enqueue it
     enqueueAction(c.id, async () => await ChatManager.handleDamageModifierDialogRender(combatant, app));
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,6 +358,16 @@ export async function enqueueAction(combatantId: string, actionFn: () => Promise
     });
 
     _queues.set(combatantId, newPromise);
+
+    // Drop the entry once it settles, but only if no later enqueueAction has replaced the head.
+    // Without this, the map accumulates one resolved Promise per combatant ever queued, growing
+    // unboundedly across long sessions.
+    newPromise.finally(() => {
+        if (_queues.get(combatantId) === newPromise) {
+            _queues.delete(combatantId);
+        }
+    });
+
     return newPromise;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { findPf2eHudTracker } from "./trackerAdapters";
 // string is the combatant ID.
 const _queues = new Map<string, Promise<void>>();
 let pf2eHudObserver: MutationObserver | undefined;
+let pf2eHudObservedCombatId: string | undefined;
 let isReady = false;
 
 function syncPf2eHudTracker(combat: any): boolean {
@@ -41,6 +42,7 @@ function observePf2eHudTracker(combat: any): boolean {
         }
     });
     pf2eHudObserver.observe(hudTracker, { childList: true, subtree: true });
+    pf2eHudObservedCombatId = combat.id;
     return true;
 }
 
@@ -128,6 +130,16 @@ Hooks.on("deleteChatMessage", async (message: ChatMessagePF2e) => {
 // End of Combat hook
 Hooks.on("deleteCombat", async (combat: EncounterPF2e) => {
     const g = game as unknown as Game;
+
+    // Per-client cleanup runs on every client (not just the GM): the MutationObserver holds a
+    // closure reference to the ended combat and would otherwise keep observing the HUD tracker
+    // DOM until the next renderCombatTracker fires. Match the observed combat id so we don't
+    // tear down a newer observer that has already moved on.
+    if (pf2eHudObserver && pf2eHudObservedCombatId === combat.id) {
+        pf2eHudObserver.disconnect();
+        pf2eHudObserver = undefined;
+        pf2eHudObservedCombatId = undefined;
+    }
 
     if (game.user?.id !== game.users?.activeGM?.id) return;
 


### PR DESCRIPTION
## Summary

Five small, focused fixes uncovered while auditing the module against Foundry V14 (build 14.360) and PF2E 8.1.1. Each is a separate commit so they can be cherry-picked or reverted individually. None overlaps with #51 or #53 (different lines, different files).

## Fixes

### 1. `_queues` Map memory leak — `bc3b940`
`enqueueAction` set entries into the `_queues: Map<combatantId, Promise>` but nothing ever removed them. Across long sessions one resolved Promise per combatant ever queued accumulated, preventing GC of the chain.

Attached a `.finally()` cleanup with an identity check so we only delete when no later `enqueueAction` has replaced the head.

### 2. `pf2e-hud` MutationObserver leak on `deleteCombat` — `4475a9b`
`pf2eHudObserver`'s callback closes over the rendering combat. After combat ends the observer keeps watching the HUD tracker DOM until the next `renderCombatTracker` replaces it, holding a stale combat reference.

Tracked the observed combat id alongside the observer (`pf2eHudObservedCombatId`) and disconnect on `deleteCombat` only when ids match — so we never tear down a newer observer that has already moved on. Cleanup runs on every client (not just GM) since the observer is per-client UI.

### 3. `MovementManager` per-token state leak on `deleteToken` — `a6afa2d`
`MovementManager._capturedHistory` / `_historyLengths` / `_lastCoords` / `_lastInteractionDistance` are keyed by `tokenId` and pruned only by `resetCapturedHistory`. Tokens deleted from a scene mid-campaign left their entries behind forever.

Added a `deleteToken` hook that calls the existing `resetCapturedHistory(tokenId)`.

### 4. `libWrapper.register` guarded against missing PF2E targets — `4eb2429`
The three `libWrapper.register` calls (`game.pf2e.Check.rerollFromMessage`, `CONFIG.PF2E.Item.documentClasses.spellcastingEntry.prototype.cast`, `…consumable.prototype.consume`) were chained without try/catch. If a PF2E rename or system-load race made any single target missing, the throw aborted `wrapFunctions` and left subsequent wrappers unregistered.

Introduced a `tryRegister` helper that catches per-target failures and degrades to a `logWarn` instead of throwing.

### 5. Removed unreachable `_wasRolled` dead-code check — `1bf8b7c`
`if (app.element?.[0]?._wasRolled) return;` in the `closeDamageModifierDialog` handler guarded against a property nothing in this module or PF2E ever sets. The condition is always falsy and the `return` was dead code. Dropped it and renumbered the surrounding step comments.

(If a future change wants the original short-circuit semantics, the right shape is a flag set by the post-roll handler on the dialog itself; left as a follow-up rather than reviving the dead check.)

## Relationship to other PRs

Independent of #51 and #53 — touches different lines than either. Applies cleanly to `main`, `roi007leaf:v14`, or any combination. Maintainer can land in any order.

## Test plan

- [x] Build (`npm run build`) clean — bundle includes all five fixes (`.finally(...)`, `pf2eHudObservedCombatId`, `Hooks.on(\"deleteToken\", ...)`, `libWrapper failed to wrap`, no `_wasRolled` references).
- [x] Bundle is syntactically valid (`node --check dist/main.js`).
- [x] Deployed combined build (PR #51 + #53 + this PR) to a Foundry V14.360 + PF2E 8.1.1 install for verification.
- [ ] Long-session smoke test: many combats over a session — `_queues.size` stays bounded.
- [ ] `deleteToken` handler clears MovementManager Maps for the deleted tokenId.
- [ ] `deleteCombat` disconnects `pf2eHudObserver` only when the deleted combat is the one being observed.
- [ ] Manual edit: temporarily rename `game.pf2e.Check.rerollFromMessage` → confirm the other two wrappers still register and a `logWarn` appears for the missing one.