### PR TITLE
Closes #69 - Fix issue where sustaining NPC spells (and sustain confi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2e-auto-action-tracker",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/ChatCardRenderer.ts
+++ b/src/ChatCardRenderer.ts
@@ -200,6 +200,12 @@ export class ChatCardRenderer {
         const combatant = findCombatantById(game.combat, combatantId);
         const token = (combatant as any)?.token;
 
+        const gmUserIds = game.users.filter((u: any) => u.isGM).map((u: any) => u.id);
+        const ownerUserIds = Object.entries(actor.ownership || {})
+            .filter(([id, level]) => level === 3 && id !== "default")
+            .map(([id]) => id);
+        const whisperUserIds = Array.from(new Set([...gmUserIds, ...ownerUserIds]));
+
         await ChatMessage.create({
             speaker: {
                 actor: actor.id,
@@ -207,6 +213,7 @@ export class ChatCardRenderer {
                 scene: token?.parent?.id,
                 alias: actor.name
             },
+            whisper: whisperUserIds,
             flavor: `<h4 class="action"><strong>Sustain</strong> <span class="action-glyph">1</span></h4>`,
             content: `<div class="pf2e">Sustaining <strong>@UUID[${item?.uuid}]{${displayName}}</strong></div>`,
             flags: {

--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -304,11 +304,15 @@ export class ChatManager {
                     itemName: itemName
                 });
 
-                const recipients = ChatMessage.getWhisperRecipients(actor.name);
+                const gmUserIds = game.users.filter((u: any) => u.isGM).map((u: any) => u.id);
+                const ownerUserIds = Object.entries(actor.ownership || {})
+                    .filter(([id, level]) => level === 3 && id !== "default")
+                    .map(([id]) => id);
+                const whisperUserIds = Array.from(new Set([...gmUserIds, ...ownerUserIds]));
 
                 await ChatMessage.create({
                     content: content,
-                    whisper: recipients.map((u: any) => u.id),
+                    whisper: whisperUserIds,
                     speaker: ChatMessage.getSpeaker({ actor: actor })
                 });
             }


### PR DESCRIPTION
…rmations) would create public chat cards instead of whispering GM(s)

## Automated Action Tracker - Release PR

### Pre-Merge Checklist
- [ x ] **Version Bump:** I have updated the version in `package.json` (Current: ).
- [ x ] **Local Check:** The `dist/main.js` has been built and looks correct.
- [ x ] **Issue Linking:** This PR closes the issue listed below.

### Associated Issue
Closes #69 

### Change Summary
- Add a fix for sustain reminders and confirmation of sustaining were not being whispered for NPCs sustaining spells.