### PR TITLE
Closes #63 Make sustaining a spell better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2e-auto-action-tracker",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/ActionManager.ts
+++ b/src/ActionManager.ts
@@ -619,6 +619,16 @@ export class ActionManager {
             await Promise.allSettled(messageIds.map(id => ChatManager.deleteMessage(id)));
         }
 
+        // Revert choice on reminder message if exists
+        const primaryMessage = (game as any).messages.get(entry.msgId);
+        const reminderMessageId = primaryMessage?.getFlag(SCOPE, "reminderMessageId");
+        if (reminderMessageId) {
+            const reminderMsg = (game as any).messages.get(reminderMessageId);
+            if (reminderMsg) {
+                await reminderMsg.unsetFlag(SCOPE, "sustainChoice");
+            }
+        }
+
         // 7. Delete the primary message
         await ChatManager.deleteMessage(entry.msgId);
     }

--- a/src/ChatCardRenderer.ts
+++ b/src/ChatCardRenderer.ts
@@ -1,6 +1,8 @@
 import { SCOPE, recentIntent } from "./globals.ts";
 import { getActorAndTokenFromSheet, findCombatantByMessage, findCombatantById, findCombatantByTokenOrActor } from "./foundryCompat.ts";
 import { ChatPendingState } from "./ChatPendingState.ts";
+import { logInfo } from "./logger.ts";
+
 
 export class ChatCardRenderer {
     public static lastClickedMessageId: string | null = null;
@@ -17,53 +19,8 @@ export class ChatCardRenderer {
             const btnText = btn.innerText?.toLowerCase() || "";
             const btnClasses = btn.className;
 
-            const isDamageOrHealing =
-                action?.toLowerCase().includes('damage') ||
-                action?.toLowerCase().includes('healing') ||
-                btnText.includes('damage') ||
-                btnText.includes('healing');
-
-            if (action?.includes('use') || action?.includes('consume') || action?.includes('activate') || action?.includes('cast')) {
-                const itemId = btn.dataset.itemId ||
-                    btn.closest('[data-item-id]')?.getAttribute('data-item-id') ||
-                    btn.closest('.item')?.getAttribute('data-item-id') ||
-                    btn.closest('[data-id]')?.getAttribute('data-id');
-
-                const slug = btn.dataset.slug ||
-                    btn.closest('[data-item-slug]')?.getAttribute('data-item-slug') ||
-                    btn.closest('[data-slug]')?.getAttribute('data-slug') ||
-                    btn.closest('.item')?.getAttribute('data-item-slug');
-
-                const actorId = btn.closest('[data-actor-id]')?.getAttribute('data-actor-id') ||
-                    btn.closest('.sheet')?.getAttribute('data-actor-id') ||
-                    btn.closest('[data-document-id]')?.getAttribute('data-document-id');
-                const tokenId = btn.closest('[data-token-id]')?.getAttribute('data-token-id') ||
-                    btn.closest('.sheet')?.getAttribute('data-token-id');
-
-                // --- Identify Actor/Token from Sheet ---
-                const sheetElement = btn.closest<HTMLElement>('.sheet');
-                const { actor, actorId: sheetActorId, tokenId: sheetTokenId } = getActorAndTokenFromSheet(sheetElement);
-
-                const finalActorId = actorId || sheetActorId || btn.closest('[data-actor-id]')?.getAttribute('data-actor-id');
-                const finalTokenId = tokenId || sheetTokenId || btn.closest('[data-token-id]')?.getAttribute('data-token-id');
-
-                const uniqueKey = finalTokenId || finalActorId;
-
-                if (uniqueKey && (itemId || slug)) {
-                    recentIntent.set(uniqueKey, (itemId || slug || ""));
-
-                    // --- Capture Item State for Enhanced Undo ---
-                    const item = actor?.items.get(itemId) || (slug ? actor?.items.find((i: any) => i.slug === slug) : null);
-                    if (item && item.type !== "spellcastingEntry") {
-                        ChatPendingState.setPendingItemUsage(actor.uuid, {
-                            uuid: item.uuid,
-                            quantity: item.system.quantity !== undefined ? foundry.utils.deepClone(item.system.quantity) : undefined,
-                            uses: item.system.uses !== undefined ? foundry.utils.deepClone(item.system.uses) : undefined,
-                            frequency: item.system.frequency !== undefined ? foundry.utils.deepClone(item.system.frequency) : undefined
-                        }, actor.token?.uuid);
-                    }
-                }
-            }
+            this.handleSustainMessageItemInjection(messageId);
+            await this.handleItemStateCapture(btn, action);
 
             const lowerAction = action?.toLowerCase() || "";
             const isApplyButton =
@@ -72,7 +29,13 @@ export class ChatCardRenderer {
                 lowerAction.includes("applyhealing") ||
                 btnText.includes('apply damage');
 
-            if (btn.matches('[data-action="strike-damage"], [data-action="strike-critical"], [data-action="spell-damage"], [data-action="damage"]') || btnText.includes('damage roll')) {
+            const isAttack =
+                action?.toLowerCase().includes('attack') ||
+                btnText.includes('attack');
+
+            if (btn.matches('[data-action="strike-attack"], [data-action="spell-attack"]') || isAttack) {
+                await this.handleAttackButtonClick(btn);
+            } else if (btn.matches('[data-action="strike-damage"], [data-action="strike-critical"], [data-action="spell-damage"], [data-action="damage"]') || btnText.includes('damage roll')) {
                 await this.handleDamageButtonClick(btn);
             } else if (btn.matches('[data-action="toggle-crit-immune"]')) {
                 await this.handleToggleCritImmuneClick(btn);
@@ -83,6 +46,83 @@ export class ChatCardRenderer {
                 }
             }
         }, { capture: true });
+    }
+
+    private static handleSustainMessageItemInjection(messageId: string | null | undefined) {
+        if (!messageId) return;
+        const message = game.messages.get(messageId);
+        if (message && (message as any).getFlag(SCOPE, "isSustainAutomation")) {
+            const itemId = (message as any).getFlag(SCOPE, "sustainedItemId") as string;
+            const actor = message.actor;
+            if (actor && itemId) {
+                Object.defineProperty(message, "item", {
+                    get() {
+                        return actor.items.get(itemId) || null;
+                    },
+                    configurable: true
+                });
+            }
+        }
+    }
+
+    private static async handleItemStateCapture(btn: HTMLButtonElement, action: string | undefined) {
+        if (!action) return;
+        if (action.includes('use') || action.includes('consume') || action.includes('activate') || action.includes('cast')) {
+            const itemId = btn.dataset.itemId ||
+                btn.closest('[data-item-id]')?.getAttribute('data-item-id') ||
+                btn.closest('.item')?.getAttribute('data-item-id') ||
+                btn.closest('[data-id]')?.getAttribute('data-id');
+
+            const slug = btn.dataset.slug ||
+                btn.closest('[data-item-slug]')?.getAttribute('data-item-slug') ||
+                btn.closest('[data-slug]')?.getAttribute('data-slug') ||
+                btn.closest('.item')?.getAttribute('data-item-slug');
+
+            const actorId = btn.closest('[data-actor-id]')?.getAttribute('data-actor-id') ||
+                btn.closest('.sheet')?.getAttribute('data-actor-id') ||
+                btn.closest('[data-document-id]')?.getAttribute('data-document-id');
+            const tokenId = btn.closest('[data-token-id]')?.getAttribute('data-token-id') ||
+                btn.closest('.sheet')?.getAttribute('data-token-id');
+
+            // --- Identify Actor/Token from Sheet ---
+            const sheetElement = btn.closest<HTMLElement>('.sheet');
+            const { actor, actorId: sheetActorId, tokenId: sheetTokenId } = getActorAndTokenFromSheet(sheetElement);
+
+            const finalActorId = actorId || sheetActorId || btn.closest('[data-actor-id]')?.getAttribute('data-actor-id');
+            const finalTokenId = tokenId || sheetTokenId || btn.closest('[data-token-id]')?.getAttribute('data-token-id');
+
+            const uniqueKey = finalTokenId || finalActorId;
+
+            if (uniqueKey && (itemId || slug)) {
+                recentIntent.set(uniqueKey, (itemId || slug || ""));
+
+                // --- Capture Item State for Enhanced Undo ---
+                const item = actor?.items.get(itemId) || (slug ? actor?.items.find((i: any) => i.slug === slug) : null);
+                if (item && item.type !== "spellcastingEntry") {
+                    ChatPendingState.setPendingItemUsage(actor.uuid, {
+                        uuid: item.uuid,
+                        quantity: item.system.quantity !== undefined ? foundry.utils.deepClone(item.system.quantity) : undefined,
+                        uses: item.system.uses !== undefined ? foundry.utils.deepClone(item.system.uses) : undefined,
+                        frequency: item.system.frequency !== undefined ? foundry.utils.deepClone(item.system.frequency) : undefined
+                    }, actor.token?.uuid);
+                }
+            }
+        }
+    }
+
+    private static async handleAttackButtonClick(btn: HTMLButtonElement) {
+        const chatMessage = btn.closest('.chat-message');
+        const originMsgId = chatMessage?.getAttribute('data-message-id');
+        if (!originMsgId) return;
+
+        const message = game.messages.get(originMsgId);
+        const combatant = findCombatantByMessage((game as any).combat, message);
+        if (!combatant) return;
+
+        const c = combatant as any;
+        const queue = (c.getFlag(SCOPE, 'pendingAttackQueue') as string[]) || [];
+        queue.push(originMsgId);
+        await c.setFlag(SCOPE, 'pendingAttackQueue', queue);
     }
 
     private static async handleDamageButtonClick(btn: HTMLButtonElement) {
@@ -140,26 +180,74 @@ export class ChatCardRenderer {
         const sustainButtons = html.querySelectorAll<HTMLButtonElement>("button[data-action^='sustain-']");
         if (sustainButtons.length === 0) return;
 
-        const choiceData = message.getFlag(SCOPE, "sustainChoice") as { choice: string, itemName: string };
+        const choiceData = message.getFlag(SCOPE, "sustainChoice") as { choice: string, itemName: string, combatantId?: string, itemId?: string };
 
         if (choiceData) {
-            const card = html.querySelector(".pf2e-auto-action-tracker-sustain-card");
-            if (!card) return;
-            const yesBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-yes']");
-            const noBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-no']");
-            if (!yesBtn || !noBtn) return;
-            if (choiceData.choice === "yes") {
-                yesBtn.innerHTML = '<i class="fas fa-check"></i> Sustained';
-                yesBtn.disabled = true;
-                noBtn.style.display = "none";
-            } else {
-                noBtn.innerHTML = '<i class="fas fa-times"></i> Lapsed';
-                noBtn.disabled = true;
-                yesBtn.style.display = "none";
-            }
-            return;
+            this.renderSustainChoiceState(message, html, choiceData);
+        } else {
+            this.setupSustainButtons(message, sustainButtons);
+        }
+    }
+
+    private static renderSustainChoiceState(message: any, html: HTMLElement, choiceData: { choice: string, itemName: string, combatantId?: string, itemId?: string }) {
+        const card = html.querySelector(".pf2e-auto-action-tracker-sustain-card");
+        if (!card) return;
+        const yesBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-yes']");
+        const noBtn = card.querySelector<HTMLButtonElement>("button[data-action='sustain-no']");
+        if (!yesBtn || !noBtn) return;
+        if (choiceData.choice === "yes") {
+            yesBtn.innerHTML = '<i class="fas fa-check"></i> Sustained';
+            yesBtn.disabled = true;
+            noBtn.style.display = "none";
+        } else {
+            noBtn.innerHTML = '<i class="fas fa-times"></i> Lapsed';
+            noBtn.disabled = true;
+            yesBtn.style.display = "none";
         }
 
+        const flexContainer = card.querySelector(".flexrow");
+        if (!flexContainer) return;
+
+        const resetBtn = document.createElement("button");
+        resetBtn.type = "button";
+        resetBtn.className = "pf2e-sustain-reset-btn";
+        resetBtn.style.width = "auto";
+        resetBtn.style.flex = "0 0 auto";
+        resetBtn.innerHTML = '<i class="fas fa-undo"></i>';
+        resetBtn.title = "Reset Choice";
+        resetBtn.style.marginLeft = "5px";
+        resetBtn.addEventListener("click", async (e) => {
+            e.preventDefault();
+            const payload = {
+                messageId: message.id,
+                combatantId: choiceData.combatantId || message.flags?.[SCOPE]?.combatantId,
+                itemId: choiceData.itemId || message.flags?.[SCOPE]?.itemId,
+                choice: choiceData.choice
+            };
+
+            if (game.user.isGM) {
+                if (choiceData.choice === "yes") {
+                    const cId = payload.combatantId;
+                    const combatant = findCombatantById(game.combat, cId);
+                    if (combatant) {
+                        const { ActionManager } = await import("./ActionManager.ts");
+                        const logs = ActionManager.getFlattenedActions(combatant);
+                        const sustainAction = logs.find(log => log.slug === "sustain-a-spell" && log.sustainItem?.id === payload.itemId);
+                        if (sustainAction) {
+                            await ActionManager.removeAction(combatant, sustainAction.msgId);
+                        }
+                    }
+                }
+                await (message as any).unsetFlag(SCOPE, "sustainChoice");
+            } else {
+                const { SocketsManager } = await import("./SocketManager.ts");
+                SocketsManager.emitResetSustainChoice(payload);
+            }
+        });
+        flexContainer.appendChild(resetBtn);
+    }
+
+    private static setupSustainButtons(message: any, sustainButtons: NodeListOf<HTMLButtonElement>) {
         sustainButtons.forEach((button) => {
             button.addEventListener("click", async (event) => {
                 event.preventDefault();
@@ -180,12 +268,12 @@ export class ChatCardRenderer {
 
                 if (game.user.isGM) {
                     if (choice === "yes") {
-                        await this.processSustainYes(actor, itemId || "", itemName || "", combatantId);
+                        await this.processSustainYes(actor, itemId || "", itemName || "", combatantId, message.id);
                     } else {
                         const combatant = findCombatantById(game.combat, combatantId);
                         await this.processSustainNo(actor, itemId || "", combatant);
                     }
-                    await (message as any).setFlag(SCOPE, "sustainChoice", { choice, itemName });
+                    await (message as any).setFlag(SCOPE, "sustainChoice", { choice, itemName, combatantId, itemId });
                 } else {
                     const { SocketsManager } = await import("./SocketManager.ts");
                     SocketsManager.emitSustainChoice(payload);
@@ -194,11 +282,13 @@ export class ChatCardRenderer {
         });
     }
 
-    public static async processSustainYes(actor: any, itemId: string, itemName: string, combatantId?: string) {
+    public static async processSustainYes(actor: any, itemId: string, itemName: string, combatantId?: string, reminderMessageId?: string) {
         const item = actor.items.get(itemId);
         const displayName = itemName || item?.name || "Action";
         const combatant = findCombatantById(game.combat, combatantId);
         const token = (combatant as any)?.token;
+
+        const spellContent = item ? await this.getSustainSpellCardContent(item) : "";
 
         const gmUserIds = game.users.filter((u: any) => u.isGM).map((u: any) => u.id);
         const ownerUserIds = Object.entries(actor.ownership || {})
@@ -215,7 +305,12 @@ export class ChatCardRenderer {
             },
             whisper: whisperUserIds,
             flavor: `<h4 class="action"><strong>Sustain</strong> <span class="action-glyph">1</span></h4>`,
-            content: `<div class="pf2e">Sustaining <strong>@UUID[${item?.uuid}]{${displayName}}</strong></div>`,
+            content: `
+                <div class="pf2e-auto-action-tracker-sustain-card-container">
+                    <div class="pf2e">Sustaining <strong>${displayName}</strong></div>
+                    ${spellContent}
+                </div>
+            `,
             flags: {
                 pf2e: {
                     origin: {
@@ -232,11 +327,30 @@ export class ChatCardRenderer {
                 [SCOPE]: {
                     isSustainAutomation: true,
                     sustainedItemId: itemId,
-                    sustainedItemUuid: item?.uuid,
-                    sustainedItemName: displayName
+                    sustainedItemName: displayName,
+                    reminderMessageId: reminderMessageId
                 }
             }
         } as any);
+    }
+
+    private static async getSustainSpellCardContent(item: any): Promise<string> {
+        try {
+            const messageData = await item.toMessage(undefined, { create: false });
+            if (messageData && messageData.content) {
+                let spellContent = messageData.content;
+                const uuid = item.uuid;
+                const uuidEscaped = uuid.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+                spellContent = spellContent.replace(new RegExp(`data-item-uuid=["']${uuidEscaped}["']`, "g"), "");
+                spellContent = spellContent.replace(new RegExp(`data-entry-uuid=["']${uuidEscaped}["']`, "g"), "");
+                spellContent = spellContent.replace(new RegExp(`data-uuid=["']${uuidEscaped}["']`, "g"), "");
+                spellContent = spellContent.replace(/@UUID\[[^\]]+\]\{([^\}]+)\}/g, "$1");
+                return spellContent;
+            }
+        } catch (err) {
+            console.error("PF2e Action Tracker | Failed to generate spell card content for sustain:", err);
+        }
+        return "";
     }
 
     public static async processSustainNo(actor: any, itemId: string, combatant?: any) {

--- a/src/ChatCardRenderer.ts
+++ b/src/ChatCardRenderer.ts
@@ -1,8 +1,6 @@
 import { SCOPE, recentIntent } from "./globals.ts";
 import { getActorAndTokenFromSheet, findCombatantByMessage, findCombatantById, findCombatantByTokenOrActor } from "./foundryCompat.ts";
 import { ChatPendingState } from "./ChatPendingState.ts";
-import { logInfo } from "./logger.ts";
-
 
 export class ChatCardRenderer {
     public static lastClickedMessageId: string | null = null;

--- a/src/ChatManager.ts
+++ b/src/ChatManager.ts
@@ -91,6 +91,22 @@ export class ChatManager {
             if (isSpellAttack) {
                 const { ActionManager } = await import("./ActionManager.ts");
                 const originUuid = pf2eFlags.origin?.uuid;
+
+                const queue = (c.getFlag(SCOPE, 'pendingAttackQueue') as string[]) || [];
+                if (queue.length > 0) {
+                    const originatingMsgId = queue.pop();
+                    await c.setFlag(SCOPE, 'pendingAttackQueue', queue);
+
+                    if (originatingMsgId) {
+                        const entry = ActionManager.getActionById(combatant, originatingMsgId);
+                        if (entry) {
+                            const linkedMessages = [...(entry.linkedMessages || []), { type: 'attack', msgId: message.id } as const];
+                            await ActionManager.editAction(combatant, entry.msgId, { linkedMessages });
+                            return;
+                        }
+                    }
+                }
+
                 await ActionManager.linkSpellAttackToAction(combatant, message.item?.uuid, message.item?.id, originUuid, message.item?.name, message.id);
                 return;
             }
@@ -189,14 +205,23 @@ export class ChatManager {
 
     public static async linkDamageRollToAction(combatant: CombatantPF2e, attackMsgId: string, damageMsgId: string) {
         const { ActionManager } = await import("./ActionManager.ts");
-        const entry = ActionManager.getActionById(combatant, attackMsgId);
+        let entry = ActionManager.getActionById(combatant, attackMsgId);
+
+        if (!entry) {
+            entry = ActionManager.getFlattenedActions(combatant).find(e =>
+                e.linkedMessages.some(m => m.msgId === attackMsgId)
+            );
+        }
 
         if (entry) {
             const linkedMessages = [...entry.linkedMessages, { type: 'damage', msgId: damageMsgId } as const];
-            await ActionManager.editAction(combatant, attackMsgId, { linkedMessages });
+            await ActionManager.editAction(combatant, entry.msgId, { linkedMessages });
 
             const updatedParent = ActionManager.getFlattenedActions(combatant).find(e =>
-                e.ComplexActionState && ComplexActionEngine.getAllChildMessageIds(e.ComplexActionState).includes(attackMsgId)
+                e.ComplexActionState && (
+                    ComplexActionEngine.getAllChildMessageIds(e.ComplexActionState).includes(attackMsgId) ||
+                    ComplexActionEngine.getAllChildMessageIds(e.ComplexActionState).includes(entry.msgId)
+                )
             );
 
             if (updatedParent && updatedParent.ComplexActionState) {

--- a/src/SocketManager.ts
+++ b/src/SocketManager.ts
@@ -17,6 +17,8 @@ export class SocketsManager {
 
         // Register Sustain (Player -> GM)
         this.socket.register("processSustain", this._handleSustainRequest.bind(this));
+        // Register Reset Sustain Choice (Player -> GM)
+        this.socket.register("resetSustainChoice", this._handleResetSustainChoiceRequest.bind(this));
         // Register Whisper (GM -> Everyone)
         this.socket.register("attemptWhisper", this.handleSocketWhisper.bind(this));
         // Register Movement (Player -> GM)
@@ -45,7 +47,8 @@ export class SocketsManager {
             await (msg as any).setFlag(SCOPE, "sustainChoice", {
                 choice: data.choice,
                 itemName: data.itemName,
-                combatantId: data.combatantId
+                combatantId: data.combatantId,
+                itemId: data.itemId
             });
         }
 
@@ -53,7 +56,7 @@ export class SocketsManager {
         if (actor) {
             const { ChatCardRenderer } = await import("./ChatCardRenderer.ts");
             if (data.choice === "yes") {
-                await ChatCardRenderer.processSustainYes(actor, data.itemId, data.itemName, data.combatantId);
+                await ChatCardRenderer.processSustainYes(actor, data.itemId, data.itemName, data.combatantId, data.messageId);
             } else {
                 const combatant = game.combat?.combatants.get(data.combatantId);
                 await ChatCardRenderer.processSustainNo(actor, data.itemId, combatant);
@@ -146,6 +149,30 @@ export class SocketsManager {
     static emitSustainChoice(payload: any) {
         // This automatically finds the active GM and runs the function there
         this.socket.executeAsGM("processSustain", payload);
+    }
+
+    static emitResetSustainChoice(payload: any) {
+        this.socket.executeAsGM("resetSustainChoice", payload);
+    }
+
+    private static async _handleResetSustainChoiceRequest(data: any) {
+        if (!(game as any).user.isGM) return;
+
+        const message = game.messages.get(data.messageId);
+        if (message) {
+            if (data.choice === "yes" && data.combatantId) {
+                const combatant = game.combat?.combatants.get(data.combatantId);
+                if (combatant) {
+                    const { ActionManager } = await import("./ActionManager.ts");
+                    const logs = ActionManager.getFlattenedActions(combatant as any);
+                    const sustainAction = logs.find(log => log.slug === "sustain-a-spell" && log.sustainItem?.id === data.itemId);
+                    if (sustainAction) {
+                        await ActionManager.removeAction(combatant as any, sustainAction.msgId);
+                    }
+                }
+            }
+            await (message as any).unsetFlag(SCOPE, "sustainChoice");
+        }
     }
 
     static async handleSocketWhisper(data: { targetPlayerIds: string[], header: string, message: string, setting: string }) {


### PR DESCRIPTION
## Automated Action Tracker - Release PR

### Pre-Merge Checklist
- [ ] **Version Bump:** I have updated the version in `package.json` (Current: ).
- [ ] **Local Check:** The `dist/main.js` has been built and looks correct.
- [ ] **Issue Linking:** This PR closes the issue listed below.

### Associated Issue
Closes #63 

### Change Summary
- Add ability to undo sustain selection on sustain whisper card
- Refactored to break up enormous functions into smaller functions (ChatCardRenderer)
- Added subsequent rolls from sustains to sustain action so enhanced undo works.
- Added SocketManager changes so both players and GMs can undo sustains.